### PR TITLE
Update logging to logback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation ('org.springframework.boot:spring-boot-starter-data-jpa:2.5.3')
+	implementation 'ch.qos.logback:logback-classic:1.2.8'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                Logback %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <logger name="org.sonatype.cs.metrics" level="debug" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <root level="error">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
In response to [CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228) we are aligning this project to use logback in common with other Sonatype products.

log4j-core was not implemented in this project so it was not vulnerable to the above CVE, this was confirmed by running
```sh
nexusiq-successmetrics % ./gradlew dependencyInsight --dependency log4j-core      

> Task :dependencyInsight
No dependencies matching given input were found in configuration ':compileClasspath'

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 606ms
1 actionable task: 1 executed
```
Logging lines are prepended with "Logback" to highlight this update:
```sh
nexusiq-successmetrics % ./gradlew bootrun

> Task :bootRun
10:17:48,661 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
10:17:48,662 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.groovy]
10:17:48,662 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [file:/Users/rpanman/git/nexusiq-successmetrics/build/resources/main/logback.xml]
10:17:48,698 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - debug attribute not set
10:17:48,698 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
10:17:48,701 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [CONSOLE]
10:17:48,729 |-WARN in ch.qos.logback.core.ConsoleAppender[CONSOLE] - This appender no longer admits a layout as a sub-component, set an encoder instead.
10:17:48,729 |-WARN in ch.qos.logback.core.ConsoleAppender[CONSOLE] - To ensure compatibility, wrapping your layout in LayoutWrappingEncoder.
10:17:48,729 |-WARN in ch.qos.logback.core.ConsoleAppender[CONSOLE] - See also http://logback.qos.ch/codes.html#layoutInsteadOfEncoder for details
10:17:48,730 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.sonatype.cs.metrics] to DEBUG
10:17:48,730 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting additivity of logger [org.sonatype.cs.metrics] to false
10:17:48,730 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [CONSOLE] to Logger[org.sonatype.cs.metrics]
10:17:48,730 |-INFO in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to ERROR
10:17:48,730 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [CONSOLE] to Logger[ROOT]
10:17:48,730 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - End of configuration.
10:17:48,731 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@9225652 - Registering current configuration as safe fallback point

Logback 10:17:48.965 [restartedMain] INFO  o.s.c.m.SuccessMetricsApplication - Starting SuccessMetricsApplication using Java 17.0.1 on Richards-MBP.broadband with PID 4433 (/Users/rpanman/git/nexusiq-successmetrics/build/classes/java/main started by rpanman in /Users/rpanman/git/nexusiq-successmetrics)
Logback 10:17:48.966 [restartedMain] DEBUG o.s.c.m.SuccessMetricsApplication - Running with Spring Boot v2.5.6, Spring v5.3.12
Logback 10:17:48.966 [restartedMain] INFO  o.s.c.m.SuccessMetricsApplication - The following profiles are active: web
Logback 10:17:50.592 [restartedMain] INFO  o.s.c.m.SuccessMetricsApplication - Started SuccessMetricsApplication in 1.772 seconds (JVM running for 2.027)
Logback 10:17:50.609 [restartedMain] INFO  o.s.c.m.SuccessMetricsApplication - Run mode: SERVLET 
Logback 10:17:50.609 [restartedMain] INFO  o.s.c.m.SuccessMetricsApplication - Working directory: /Users/rpanman/git/nexusiq-successmetrics
Logback 10:17:50.609 [restartedMain] INFO  o.s.c.m.SuccessMetricsApplication - Active profile: web
Logback 10:17:50.610 [restartedMain] INFO  o.s.cs.metrics.service.LoaderService - Loading file: ./successmetrics.csv
Logback 10:17:50.638 [restartedMain] INFO  o.s.cs.metrics.service.LoaderService - Loaded file: ./successmetrics.csv
Logback 10:17:50.645 [restartedMain] INFO  o.s.cs.metrics.service.LoaderService - Removing incomplete data for current month 2021-07-01
Logback 10:17:50.645 [restartedMain] INFO  o.s.cs.metrics.service.LoaderService - Loading insights data
Logback 10:17:50.645 [restartedMain] INFO  o.s.cs.metrics.service.LoaderService - Mid period: 2021-04-01
Logback 10:17:50.648 [restartedMain] INFO  o.s.cs.metrics.service.LoaderService - Loading file: ./reports2/application_evaluations.csv
Logback 10:17:50.648 [restartedMain] WARN  o.s.cs.metrics.service.LoaderService - File not found: ./reports2/application_evaluations.csv
Logback 10:17:50.648 [restartedMain] INFO  o.s.cs.metrics.service.LoaderService - Loading file: ./reports2/policy_violations.csv
Logback 10:17:50.648 [restartedMain] WARN  o.s.cs.metrics.service.LoaderService - File not found: ./reports2/policy_violations.csv
Logback 10:17:50.648 [restartedMain] INFO  o.s.cs.metrics.service.LoaderService - Loading file: ./reports2/component_waivers.csv
Logback 10:17:50.648 [restartedMain] WARN  o.s.cs.metrics.service.LoaderService - File not found: ./reports2/component_waivers.csv
Logback 10:17:50.648 [restartedMain] INFO  o.s.cs.metrics.service.LoaderService - Loading file: ./reports2/quarantined_data/quarantined_components.csv
Logback 10:17:50.648 [restartedMain] WARN  o.s.cs.metrics.service.LoaderService - File not found: ./reports2/quarantined_data/quarantined_components.csv
Logback 10:17:50.648 [restartedMain] INFO  o.s.cs.metrics.service.LoaderService - Loading file: ./reports2/quarantined_data/autoreleased_from_quarantine_components.csv
Logback 10:17:50.648 [restartedMain] WARN  o.s.cs.metrics.service.LoaderService - File not found: ./reports2/quarantined_data/autoreleased_from_quarantine_components.csv
Logback 10:17:50.648 [restartedMain] INFO  o.s.c.m.SuccessMetricsApplication - Ready for viewing at http://localhost:4040
```
