### PR TITLE
Replaced Current Date with specified date for tests

### DIFF
--- a/src/main/java/org/sonatype/cs/metrics/controller/ApplicationEvaluationsController.java
+++ b/src/main/java/org/sonatype/cs/metrics/controller/ApplicationEvaluationsController.java
@@ -1,5 +1,7 @@
 package org.sonatype.cs.metrics.controller;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -8,11 +10,11 @@ import org.slf4j.LoggerFactory;
 import org.sonatype.cs.metrics.model.DbRowStr;
 import org.sonatype.cs.metrics.service.DbService;
 import org.sonatype.cs.metrics.util.HelperService;
-import org.sonatype.cs.metrics.util.SqlStatements;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class ApplicationEvaluationsController {
@@ -24,15 +26,26 @@ public class ApplicationEvaluationsController {
     @Autowired
     private HelperService helperService;
 
+
     @GetMapping({ "/evaluations" })
-    public String applicationEvaluations(Model model) {
+    public String applicationEvaluations(Model model, @RequestParam(name="date", required = false) String comparisonDate) {
 
         log.info("In ApplicationEvaluationsController");
+        if (comparisonDate == null) {
+            LocalDate dateObj = LocalDate.now();
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            comparisonDate = dateObj.format(formatter);
+        }
 
-        List<DbRowStr> age7Data =  dbService.runSqlStr(SqlStatements.ApplicationEvaluationsAge7);
-		List<DbRowStr> age30Data = dbService.runSqlStr(SqlStatements.ApplicationEvaluationsAge30);
-		List<DbRowStr> age60Data =  dbService.runSqlStr(SqlStatements.ApplicationEvaluationsAge60);
-        List<DbRowStr> age90Data =  dbService.runSqlStr(SqlStatements.ApplicationEvaluationsAge90);
+        String ApplicationEvaluationsAge7  = String.format("select application_name as pointA, evaluation_date as pointB, stage as pointC from application_evaluation where parsedatetime(evaluation_date, 'yyyy-MM-dd', 'en') >= PARSEDATETIME('%s', 'yyyy-MM-dd') - INTERVAL '7' DAY order by 1", comparisonDate);
+        String ApplicationEvaluationsAge30 = String.format("select application_name as pointA, evaluation_date as pointB, stage as pointC from application_evaluation where parsedatetime(evaluation_date, 'yyyy-MM-dd', 'en') > PARSEDATETIME('%s', 'yyyy-MM-dd') - INTERVAL '30' DAY and PARSEDATETIME(evaluation_date, 'yyyy-MM-dd', 'en') < parsedatetime('%s', 'yyyy-MM-dd') - INTERVAL '7' DAY order by 1", comparisonDate, comparisonDate);
+        String ApplicationEvaluationsAge60 = String.format("select application_name as pointA, evaluation_date as pointB, stage as pointC from application_evaluation where parsedatetime(evaluation_date, 'yyyy-MM-dd', 'en') > PARSEDATETIME('%s', 'yyyy-MM-dd', 'en') - INTERVAL '90' DAY and PARSEDATETIME(evaluation_date, 'yyyy-MM-dd', 'en') < parsedatetime('%s', 'yyyy-MM-dd', 'en') - INTERVAL '30' DAY order by 1", comparisonDate, comparisonDate);
+        String ApplicationEvaluationsAge90 = String.format("select application_name as pointA, evaluation_date as pointB, stage as pointC from application_evaluation where parsedatetime(evaluation_date, 'yyyy-MM-dd', 'en') <= PARSEDATETIME('%s', 'yyyy-MM-dd', 'en') - INTERVAL '90' DAY order by 1", comparisonDate);
+        
+        List<DbRowStr> age7Data =  dbService.runSqlStr(ApplicationEvaluationsAge7);
+		List<DbRowStr> age30Data = dbService.runSqlStr(ApplicationEvaluationsAge30);
+		List<DbRowStr> age60Data =  dbService.runSqlStr(ApplicationEvaluationsAge60);
+        List<DbRowStr> age90Data =  dbService.runSqlStr(ApplicationEvaluationsAge90);
 
         Map<String, Object> age7Map = helperService.dataMap("age7", age7Data);
         Map<String, Object> age30Map = helperService.dataMap("age30", age30Data);

--- a/src/main/java/org/sonatype/cs/metrics/controller/PolicyViolationsAgeController.java
+++ b/src/main/java/org/sonatype/cs/metrics/controller/PolicyViolationsAgeController.java
@@ -1,5 +1,7 @@
 package org.sonatype.cs.metrics.controller;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -8,11 +10,11 @@ import org.slf4j.LoggerFactory;
 import org.sonatype.cs.metrics.model.DbRowStr;
 import org.sonatype.cs.metrics.service.DbService;
 import org.sonatype.cs.metrics.util.HelperService;
-import org.sonatype.cs.metrics.util.SqlStatements;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class PolicyViolationsAgeController {
@@ -25,14 +27,24 @@ public class PolicyViolationsAgeController {
     private HelperService helperService;
 
     @GetMapping({ "/violationsage" })
-    public String policyViolationsAge(Model model) {
+    public String policyViolationsAge(Model model, @RequestParam(name="date", required = false) String comparisonDate) {
 
         log.info("In PolicyViolationsAgeController");
+        if (comparisonDate == null) {
+            LocalDate dateObj = LocalDate.now();
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            comparisonDate = dateObj.format(formatter);
+        }
 
-        List<DbRowStr> age7Data =  dbService.runSqlStr(SqlStatements.PolicyViolationsAge7);
-		List<DbRowStr> age30Data = dbService.runSqlStr(SqlStatements.PolicyViolationsAge30);
-		List<DbRowStr> age60Data =  dbService.runSqlStr(SqlStatements.PolicyViolationsAge60);
-        List<DbRowStr> age90Data =  dbService.runSqlStr(SqlStatements.PolicyViolationsAge90);
+        String PolicyViolationsAge7 = String.format("select policy_name as pointA, application_name as pointB, open_time as pointC, component as pointD, stage as pointE, reason as pointF from policy_violation where parsedatetime(open_time, 'yyyy-MM-dd', 'en') >= PARSEDATETIME('%s', 'yyyy-MM-dd', 'en') - INTERVAL '7' DAY", comparisonDate);
+        String PolicyViolationsAge30 = String.format("select policy_name as pointA, application_name as pointB, open_time as pointC, component as pointD, stage as pointE, reason as pointF from policy_violation where parsedatetime(open_time, 'yyyy-MM-dd', 'en') > PARSEDATETIME('%s', 'yyyy-MM-dd', 'en') - INTERVAL '30' DAY and parsedatetime(open_time, 'yyyy-MM-dd', 'en') < PARSEDATETIME('%s', 'yyyy-MM-dd', 'en') - INTERVAL '7' DAY", comparisonDate, comparisonDate);
+        String PolicyViolationsAge60 = String.format("select policy_name as pointA, application_name as pointB, open_time as pointC, component as pointD, stage as pointE, reason as pointF from policy_violation where parsedatetime(open_time, 'yyyy-MM-dd', 'en') > PARSEDATETIME('%s', 'yyyy-MM-dd', 'en') - INTERVAL '90' DAY and parsedatetime(open_time, 'yyyy-MM-dd', 'en') < PARSEDATETIME('%s', 'yyyy-MM-dd', 'en') - INTERVAL '30' DAY", comparisonDate, comparisonDate);
+        String PolicyViolationsAge90 = String.format("select policy_name as pointA, application_name as pointB, open_time as pointC, component as pointD, stage as pointE, reason as pointF from policy_violation where parsedatetime(open_time, 'yyyy-MM-dd', 'en') <= PARSEDATETIME('%s', 'yyyy-MM-dd', 'en') - INTERVAL '90' DAY", comparisonDate);
+        
+        List<DbRowStr> age7Data  = dbService.runSqlStr(PolicyViolationsAge7);
+		List<DbRowStr> age30Data = dbService.runSqlStr(PolicyViolationsAge30);
+		List<DbRowStr> age60Data = dbService.runSqlStr(PolicyViolationsAge60);
+        List<DbRowStr> age90Data = dbService.runSqlStr(PolicyViolationsAge90);
 
         Map<String, Object> age7Map = helperService.dataMap("age7", age7Data);
         Map<String, Object> age30Map = helperService.dataMap("age30", age30Data);

--- a/src/main/java/org/sonatype/cs/metrics/util/SqlStatements.java
+++ b/src/main/java/org/sonatype/cs/metrics/util/SqlStatements.java
@@ -181,16 +181,6 @@ public class SqlStatements {
 	
 	
 	
-	public static String PolicyViolationsAge90 = "select policy_name as pointA, application_name as pointB, open_time as pointC, component as pointD, stage as pointE, reason as pointF from policy_violation where parsedatetime(open_time, 'yyyy-MM-dd', 'en') <= CURRENT_DATE - INTERVAL '90' DAY";
-	public static String PolicyViolationsAge60 = "select policy_name as pointA, application_name as pointB, open_time as pointC, component as pointD, stage as pointE, reason as pointF from policy_violation where parsedatetime(open_time, 'yyyy-MM-dd', 'en') > CURRENT_DATE - INTERVAL '90' DAY and parsedatetime(open_time, 'yyyy-MM-dd', 'en') < CURRENT_DATE - INTERVAL '30' DAY";
-	public static String PolicyViolationsAge30 = "select policy_name as pointA, application_name as pointB, open_time as pointC, component as pointD, stage as pointE, reason as pointF from policy_violation where parsedatetime(open_time, 'yyyy-MM-dd', 'en') > CURRENT_DATE - INTERVAL '30' DAY and parsedatetime(open_time, 'yyyy-MM-dd', 'en') < CURRENT_DATE - INTERVAL '7' DAY"; 	
-	public static String PolicyViolationsAge7 = "select policy_name as pointA, application_name as pointB, open_time as pointC, component as pointD, stage as pointE, reason as pointF from policy_violation where parsedatetime(open_time, 'yyyy-MM-dd', 'en') >= CURRENT_DATE - INTERVAL '7' DAY";
-	
-	public static String ApplicationEvaluationsAge90 = "select application_name as pointA, evaluation_date as pointB, stage as pointC from application_evaluation where parsedatetime(evaluation_date, 'yyyy-MM-dd', 'en') <= CURRENT_DATE - INTERVAL '90' DAY order by 1";
-	public static String ApplicationEvaluationsAge60 = "select application_name as pointA, evaluation_date as pointB, stage as pointC from application_evaluation where parsedatetime(evaluation_date, 'yyyy-MM-dd', 'en') > CURRENT_DATE - INTERVAL '90' DAY and parsedatetime(evaluation_date, 'yyyy-MM-dd', 'en') < CURRENT_DATE - INTERVAL '30' DAY order by 1";
-	public static String ApplicationEvaluationsAge30 = "select application_name as pointA, evaluation_date as pointB, stage as pointC from application_evaluation where parsedatetime(evaluation_date, 'yyyy-MM-dd', 'en') > CURRENT_DATE - INTERVAL '30' DAY and parsedatetime(evaluation_date, 'yyyy-MM-dd', 'en') < CURRENT_DATE - INTERVAL '7' DAY order by 1"; 
-	public static String ApplicationEvaluationsAge7 = "select application_name as pointA, evaluation_date as pointB, stage as pointC from application_evaluation where parsedatetime(evaluation_date, 'yyyy-MM-dd', 'en') >= CURRENT_DATE - INTERVAL '7' DAY order by 1"; 
-	
 	public static String ComponentsInQuarantine = "select repository as pointA, format as pointB, packageUrl as pointC, " +
 													"quarantineTime as pointD, policyName as pointE, threatLevel as pointF " +
 													"from COMPONENT_QUARANTINE order by 1 asc";

--- a/src/test/java/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.java
+++ b/src/test/java/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.java
@@ -129,7 +129,7 @@ public class SuccessMetricsWebApplicationTest {
 
 	@Test
 	public void PolicyViolationsReportPageContentTest() throws Exception {
-		String pageContents = this.restTemplate.getForObject("http://localhost:" + port + "/violationsage",
+		String pageContents = this.restTemplate.getForObject("http://localhost:" + port + "/violationsage?date=2020-12-15",
 				String.class);
 		pageContents = removeLine(pageContents, 24);
 		Approvals.verify(pageContents);
@@ -137,7 +137,7 @@ public class SuccessMetricsWebApplicationTest {
 
 	@Test
 	public void ApplicationEvaluationsReportPageContentTest() throws Exception {
-		String pageContents = this.restTemplate.getForObject("http://localhost:" + port + "/evaluations",
+		String pageContents = this.restTemplate.getForObject("http://localhost:" + port + "/evaluations?date=2021-12-15",
 				String.class);
 		pageContents = removeLine(pageContents, 23);
 		Approvals.verify(pageContents);

--- a/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.PolicyViolationsReportPageContentTest.approved.txt
+++ b/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.PolicyViolationsReportPageContentTest.approved.txt
@@ -158,10 +158,10 @@
     
     	<div id="securityAgeChart" width="400" height="400"></div>
       	<script>
-	      	var age90 = 741;
-	    	var age60 = 0;
-	    	var age30 = 0;
-	    	var age7 = 0;
+	      	var age90 = 167;
+	    	var age60 = 28;
+	    	var age30 = 4;
+	    	var age7 = 542;
 	    	
 	     	var pdata = [age7, age30, age60, age90];
 	     	var labels = ['0-7 days old', '8-30 days old', '31-60 days old', '>60 days old'];
@@ -196,13 +196,4683 @@
      
       
 <br><br><br><br>
-
+<div> 
+<h5>Security Policy Violations 0-7 Days</h5>
+<div class="container">
+<div class="row">
+<div class="col-xl mx-auto w-auto bg-white rounded">
+<div class="table-responsive table-wrapper-scroll-y custom-scrollbar">
+		
+	<table class="table table-striped table-bordered table-sm">	
+    <thead class="thead-dark">
+    <tr>
+		<th>Policy Name</th>
+		<th>Reason</th>
+		<th>Application Name</th>
+		<th>Component Name</th>
+		<th>Open Time</th>
+		<th>Stage</th>
+	</tr>
+    </thead>
+    <tbody>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-25287</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-25288</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-34552</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
+		<td>2021-07-20 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_x86_64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_i686</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-macosx_10_10_x86_64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win_amd64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win32</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-7212</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/urllib3@1.25.2?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-macosx_10_10_x86_64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-7212</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/urllib3@1.25.2?extension=tar.gz</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_i686</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_i686</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_i686</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_i686</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux2014_aarch64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-manylinux2010_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-manylinux2010_x86_64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-manylinux2010_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-manylinux2010_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-manylinux2010_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-manylinux2010_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-macosx_10_10_x86_64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win_amd64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_x86_64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35654</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-25291</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-25293</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28676</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-win32</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win32</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_10_x86_64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_10_x86_64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux2014_aarch64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_10_intel</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_10_intel</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_10_intel</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_10_intel</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_10_intel</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_10_intel</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux2014_aarch64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35653</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23437</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux2014_aarch64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27921</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27922</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27923</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-28677</td>
+      	<td>chesscom__cmorenoserrano</td>
+      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux2014_aarch64</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2018-20060</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/urllib3@1.22?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-7525</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.6.1?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp34-cp34m-win32</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2018-20060</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@15.1.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win-amd64-py2.7</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win-amd64-py2.6</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-16764</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django-make-app@0.1.3?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp27-cp27m-win32</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.11?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-17495</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:a-name/org.webjars%20swagger-ui@3.18.1</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win32-py3.2</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win32-py3.1</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py2-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2018-20060</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py2-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp27-cp27m-win32</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-12791</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-5200</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-7893</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2018-15751</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-17361</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-11651</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-25592</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-25281</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-25282</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-25283</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-3197</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>sonatype-2020-1057</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2018-20060</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/botocore@1.10.70?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-16764</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django-make-app@0.1.3?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_9_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-16616</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyanyapi@0.6.0?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>sonatype-2018-0010</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyanyapi@0.6.0?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>sonatype-2020-0149</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/codecov@2.0.15?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_6_intel</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp27-cp27m-win_amd64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp34-cp34m-manylinux1_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2018-20060</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21344</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21345</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21346</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21347</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21350</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.11?extension=zip</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win32-py3.4</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2014-0474</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2016-9013</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-19844</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2018-20060</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/botocore@1.10.70?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win-amd64-py3.2</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp27-cp27mu-manylinux1_i686</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>sonatype-2015-0002</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/commons-collections/commons-collections@3.2.1?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2014-0474</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2016-9013</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-19844</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2018-20060</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-16618</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/owlmixin@1.2.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp34-cp34m-macosx_10_6_intel</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>sonatype-2020-0988</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:a-name/datatables@1.10.9</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2018-20060</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@15.1.0?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp27-cp27m-manylinux1_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win-amd64-py3.4</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_i686</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp27-cp27m-macosx_10_9_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2018-20060</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/urllib3@1.22?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2013-7459</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pycrypto@2.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-16763</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/confire@0.2.0?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp37-cp37m-macosx_10_9_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-16616</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyanyapi@0.6.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>sonatype-2018-0010</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyanyapi@0.6.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp27-cp27m-win_amd64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win32-py2.7</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.12?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win32-py3.3</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp37-cp37m-win32</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-0899</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/rubygems-update@1.4.1?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp37-cp37m-win_amd64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp34-cp34m-win_amd64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win-amd64-py3.1</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win32-py2.6</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp27-cp27mu-manylinux1_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-0230</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-core@2.5.12?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-17530</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-core@2.5.12?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-18342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win-amd64-py3.3</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-13091</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-10683</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>sonatype-2015-0002</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-20478</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp27-cp27mu-manylinux1_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-7525</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-0230</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2020-17530</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21342</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21344</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21345</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21346</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21347</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21350</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>sonatype-2015-0002</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>License-Banned</td>
+      	<td>CC-BY-NC-SA-4.0</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/safety-db@2017.4.19?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>License-Banned</td>
+      	<td>Proprietary-Clause</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.sonatype.nexus/nexus-platform-api@1.8.20171120-150856.6c36986?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>License-Banned</td>
+      	<td>AGPL-3.0</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyfsmlib@1.0?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>License-Banned</td>
+      	<td>AGPL-3.0</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyhwp@0.1b9?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>License-Banned</td>
+      	<td>CC-BY-NC-SA-4.0</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/safety-db@2017.4.19?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-11324</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/urllib3@1.22?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/matplotlib@1.3.1?extension=whl&amp;qualifier=cp33-cp33m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2017-17042</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/yard@0.8.7?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/yard@0.8.7?platform=ruby</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0309</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/yard@0.8.7?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-15560</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pycryptodome@3.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/simplecov-html@0.7.1?platform=ruby</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-18074</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@15.1.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-20225</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@15.1.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-20907</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@15.1.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-20916</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@15.1.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2012-0071</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@15.1.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-15560</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pycryptodome@3.6.1?extension=whl&amp;qualifier=cp27-cp27mu-manylinux1_x86_64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0866</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/lxml@4.1.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27291</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pygments@2.2.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2020-1357</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pygments@2.2.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-15560</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pycryptodome@3.6.1?extension=whl&amp;qualifier=cp27-cp27m-macosx_10_6_intel</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-18074</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py2-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-10906</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py2-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-11324</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py2-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-20907</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py2-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27291</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pygments@2.1.2?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2020-1357</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pygments@2.1.2?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-15560</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pycryptodome@3.6.1?extension=whl&amp;qualifier=cp27-cp27m-win32</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-28243</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-35662</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-21996</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-09-20 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-31607</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-18074</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/botocore@1.10.70?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2014-0038</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:npm/shelljs@0.3.0</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pyobjc-core@2.5.1?extension=tar.gz</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-10800</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/codecov@2.0.15?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2016-10745</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/jinja2@2.5.4?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-10906</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/jinja2@2.5.4?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/jinja2@2.5.4?extension=tar.gz</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-18074</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pip@18.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-20225</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pip@18.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-20907</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pip@18.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-20916</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pip@18.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2012-0071</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pip@18.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-14322</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/werkzeug@0.14.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-14806</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/werkzeug@0.14.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-18074</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-10906</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-11324</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-20907</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2016-3674</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2017-7957</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-26217</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-26258</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-21343</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-21348</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-21349</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-18074</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/requests@2.18.4?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2014-3483</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/activerecord@4.0.0?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2014-3514</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/activerecord@4.0.0?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2017-17916</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/activerecord@4.0.0?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2017-17917</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/activerecord@4.0.0?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2017-17919</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/activerecord@4.0.0?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2017-17920</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/activerecord@4.0.0?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-22880</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/activerecord@4.0.0?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2014-10077</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/i18n@0.6.4?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0866</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/lxml@4.2.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2015-5143</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2015-5145</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2016-2512</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2016-7401</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2016-9014</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-14232</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-14235</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-24584</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-31542</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-33571</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-13757</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/rsa@3.4.2?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/py2app@0.7.3?extension=tar.gz</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-18074</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/botocore@1.10.70?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2015-5143</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2015-5145</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2016-2512</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2016-7401</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2016-9014</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-14232</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-14235</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-24584</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-31542</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-33571</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-14322</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/werkzeug@0.14.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-14806</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/werkzeug@0.14.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2014-0114</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/commons-beanutils/commons-beanutils@1.9.2?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-18074</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-10906</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-11324</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-20907</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2017-0355</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-core@2.6.1?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-18074</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@15.1.0?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-20225</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@15.1.0?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-20907</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@15.1.0?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-20916</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@15.1.0?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2012-0071</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@15.1.0?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2017-9805</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-plugin@2.5.12?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-11776</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-plugin@2.5.12?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-1327</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-plugin@2.5.12?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-1000656</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/flask@0.6?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-1010083</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/flask@0.6?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/aruba@0.5.3?platform=ruby</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-11324</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/urllib3@1.22?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-6594</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pycrypto@2.6.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/modulegraph@0.10.4?extension=tar.gz</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/cucumber@1.2.5?platform=ruby</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/safety-db@2017.4.19?extension=tar.gz</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-20225</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pip@10.0.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-20907</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pip@10.0.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-20916</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pip@10.0.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2012-0071</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pip@10.0.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/matplotlib@1.3.1?extension=whl&amp;qualifier=cp34-cp34m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2014-0114</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/commons-beanutils/commons-beanutils@1.9.3?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27291</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pygments@2.1.2?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2013-0069</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pygments@2.1.2?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pygments@2.1.2?extension=tar.gz</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2020-1357</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pygments@2.1.2?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-13757</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/rsa@3.4.2?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0870</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.freemarker/freemarker@2.3.23?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/macholib@1.5.1?extension=tar.gz</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/matplotlib@1.3.1?extension=whl&amp;qualifier=cp27-none-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:a-name/jquery@3.3.1</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-8320</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/rubygems-update@1.4.1?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-8321</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/rubygems-update@1.4.1?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-8322</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/rubygems-update@1.4.1?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-8323</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/rubygems-update@1.4.1?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-8325</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/rubygems-update@1.4.1?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2021-0729</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/rubygems-update@1.4.1?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-20225</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@16.0.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-20907</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@16.0.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-20916</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@16.0.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2012-0071</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/virtualenv@16.0.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:a-name/jQuery@1.8.0</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-29651</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/py@1.7.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/altgraph@0.10.2?extension=tar.gz</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-15560</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/pycryptodome@3.6.1?extension=whl&amp;qualifier=cp27-cp27m-win_amd64</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2013-1424</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/matplotlib@1.3.1?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/matplotlib@1.3.1?extension=tar.gz</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-1000201</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:gem/ffi@1.9.0?platform=ruby</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:npm/jquery-ui@1.12.1</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-10906</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/jinja2@2.10?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:a-name/jquery@2.1.3</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2017-9804</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-core@2.5.12?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-11776</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-core@2.5.12?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-0233</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-core@2.5.12?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-18074</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:pypi/requests@2.18.4?extension=tar.gz</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2012-0881</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2013-4002</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2016-1000338</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2016-1000343</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-1000632</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-0231</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2014-0114</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2016-3674</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2017-7957</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2017-9804</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2017-9805</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-11776</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2018-1327</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2019-0233</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-26217</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-26258</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-21343</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-21348</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-21349</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2017-0355</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0870</td>
+      	<td>se-scripts__cmorenoserrano</td>
+      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
+		<td>2021-08-29 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21342</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21344</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21345</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21346</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21347</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21350</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-37714</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/org.jsoup/jsoup@1.11.3?type=jar</td>
+		<td>2021-08-27 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:a-name/org.webjars%20jquery@1.10.2</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-22112</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/org.springframework.security/spring-security-web@4.2.10.RELEASE?type=jar</td>
+		<td>2021-03-04 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-25649</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.11.3?type=jar</td>
+		<td>2020-12-10 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2021-1175</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/ch.qos.logback/logback-core@1.1.11?type=jar</td>
+		<td>2021-09-20 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:a-name/jQuery@1.6.4</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-17527</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.35?type=jar</td>
+		<td>2020-12-10 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-25122</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.35?type=jar</td>
+		<td>2021-03-09 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-41079</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.35?type=jar</td>
+		<td>2021-09-20 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23358</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:a-name/underscore@1.7.0</td>
+		<td>2021-07-07 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-26258</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2020-12-18 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-21343</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-21348</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-21349</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-04-01 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:a-name/jquery@2.2.4</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-31799</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
+		<td>2021-08-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2021-0729</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
+		<td>2021-06-29 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2021-1118</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
+		<td>2021-09-11 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-33503</td>
+      	<td>success-metrics__cmorenoserrano</td>
+      	<td>pkg:pypi/urllib3@1.25.8?extension=tar.gz</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-33503</td>
+      	<td>success-metrics__cmorenoserrano</td>
+      	<td>pkg:pypi/urllib3@1.25.8?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-07-19 00:00:00</td>
+		<td>source</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>Successmetrics</td>
+      	<td>pkg:pypi/tables@3.5.2?extension=tar.gz</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27291</td>
+      	<td>Successmetrics</td>
+      	<td>pkg:pypi/pygments@2.4.2?extension=tar.gz</td>
+		<td>2021-03-26 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2020-1357</td>
+      	<td>Successmetrics</td>
+      	<td>pkg:pypi/pygments@2.4.2?extension=tar.gz</td>
+		<td>2021-02-05 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-27291</td>
+      	<td>Successmetrics</td>
+      	<td>pkg:pypi/pygments@2.4.2?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-03-26 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2020-1357</td>
+      	<td>Successmetrics</td>
+      	<td>pkg:pypi/pygments@2.4.2?extension=whl&amp;qualifier=py2.py3-none-any</td>
+		<td>2021-02-05 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21342</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21344</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21345</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21346</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21347</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2021-21350</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2017-5929</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/ch.qos.logback/logback-classic@1.1.11?type=jar</td>
+		<td>2021-08-24 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-37714</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/org.jsoup/jsoup@1.11.3?type=jar</td>
+		<td>2021-08-27 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:a-name/org.webjars%20jquery@1.10.2</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-22112</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/org.springframework.security/spring-security-web@4.2.10.RELEASE?type=jar</td>
+		<td>2021-03-04 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-25649</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.11.3?type=jar</td>
+		<td>2020-12-10 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2021-1175</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/ch.qos.logback/logback-core@1.1.11?type=jar</td>
+		<td>2021-09-20 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:a-name/jQuery@1.6.4</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-17527</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.35?type=jar</td>
+		<td>2020-12-10 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-25122</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.35?type=jar</td>
+		<td>2021-03-09 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-41079</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.35?type=jar</td>
+		<td>2021-09-20 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-23358</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:a-name/underscore@1.7.0</td>
+		<td>2021-07-07 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2020-26258</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2020-12-18 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-21343</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-21348</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-03-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-21349</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2021-04-01 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:a-name/jquery@2.2.4</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-31799</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
+		<td>2021-08-28 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2021-0729</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
+		<td>2021-06-29 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2021-1118</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
+		<td>2021-09-11 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-Critical</td>
+      	<td>CVE-2019-17571</td>
+      	<td>TradingApp</td>
+      	<td>pkg:maven/log4j/log4j@1.2.17?type=jar</td>
+		<td>2021-06-14 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-22112</td>
+      	<td>TradingApp</td>
+      	<td>pkg:maven/org.springframework.security/spring-security-web@3.2.4.RELEASE?type=jar</td>
+		<td>2021-03-04 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>TradingApp</td>
+      	<td>pkg:a-name/org.webjars%20jquery@1.10.2</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-22118</td>
+      	<td>TradingApp</td>
+      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
+		<td>2021-06-14 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-37136</td>
+      	<td>TradingApp</td>
+      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
+		<td>2021-09-14 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2021-0789</td>
+      	<td>TradingApp</td>
+      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
+		<td>2021-07-08 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2010-0053</td>
+      	<td>TradingApp</td>
+      	<td>pkg:maven/log4j/log4j@1.2.17?type=jar</td>
+		<td>2021-06-14 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-22112</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/org.springframework.security/spring-security-web@3.2.4.RELEASE?type=jar</td>
+		<td>2021-03-04 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-22118</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
+		<td>2021-06-14 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>CVE-2021-37136</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
+		<td>2021-09-14 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2021-0789</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
+		<td>2021-07-08 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:a-name/org.webjars%20jquery@1.10.2</td>
+		<td>2021-09-07 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+      	<td>Security-High</td>
+      	<td>sonatype-2010-0053</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/log4j/log4j@1.2.17?type=jar</td>
+		<td>2021-06-14 00:00:00</td>
+		<td>build</td>
+    </tr>
+    </tbody>
+    </table>
+    
+</div>
+</div>
+</div>
+</div>
+</div>
 <br><br>
 
-
+<div> 
+<h5>Security Policy Violations 8-30 Days</h5>
+<div class="container">
+<div class="row">
+<div class="col-xl mx-auto w-auto bg-white rounded">
+<div class="table-responsive table-wrapper-scroll-y custom-scrollbar">
+	
+	<table class="table table-striped table-bordered table-sm">
+    <thead class="thead-dark">
+    <tr>
+		<th>Policy Name</th>
+		<th>Reason</th>
+		<th>Application Name</th>
+		<th>Component Name</th>
+		<th>Open Time</th>
+		<th>Stage</th>
+	</tr>
+    </thead>
+    <tbody>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2020-26217</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2020-12-06 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2020-25638</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/org.hibernate/hibernate-core@5.0.12.Final?type=jar</td>
+		<td>2020-11-20 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2020-26217</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
+		<td>2020-12-06 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2020-25638</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/org.hibernate/hibernate-core@5.0.12.Final?type=jar</td>
+		<td>2020-11-20 00:00:00</td>
+		<td>build</td>
+    </tr>
+    </tbody>
+    </table>
+    
+</div>
+</div>
+</div>
+</div>
+</div>
 <br><br>
 
-
+<div> 
+<h5>Security Policy Violations 31-60 Days</h5>
+<div class="container">
+<div class="row">
+<div class="col-xl mx-auto w-auto bg-white rounded">
+<div class="table-responsive table-wrapper-scroll-y custom-scrollbar">
+	
+	<table class="table table-striped table-bordered table-sm">
+	<thead class="thead-dark">
+    <tr>
+		<th>Policy Name</th>
+		<th>Reason</th>
+		<th>Application Name</th>
+		<th>Component Name</th>
+		<th>Open Time</th>
+		<th>Stage</th>
+	</tr>
+    </thead>
+    <tbody>
+    <tr>
+		<td>Security-Critical</td>
+      	<td>CVE-2017-5929</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/ch.qos.logback/logback-classic@1.1.11?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2020-25613</td>
+      	<td>SecretSauce</td>
+      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
+		<td>2020-10-22 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2020-25613</td>
+      	<td>TechEnablement</td>
+      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
+		<td>2020-10-22 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>sonatype-2020-1031</td>
+      	<td>TradingApp</td>
+      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
+		<td>2020-10-30 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-Critical</td>
+      	<td>CVE-2016-1000031</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/commons-fileupload/commons-fileupload@1.2.2?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-Critical</td>
+      	<td>sonatype-2015-0002</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/apache-collections/commons-collections@3.1?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-Critical</td>
+      	<td>CVE-2017-7525</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.0.4?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-Critical</td>
+      	<td>CVE-2018-1270</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/org.springframework/spring-expression@3.2.4.RELEASE?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2020-7238</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>sonatype-2020-0029</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>sonatype-2020-1031</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
+		<td>2020-10-30 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2015-0254</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/javax.servlet/jstl@1.2?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2019-0227</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/axis/axis@1.2?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2015-0254</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/apache-taglibs/standard@1.1.2?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2014-0114</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/commons-beanutils/commons-beanutils@1.6?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>sonatype-2017-0355</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-core@2.0.4?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>build</td>
+    </tr>
+    <tr>
+		<td>Security-Critical</td>
+      	<td>CVE-2016-1000031</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/commons-fileupload/commons-fileupload@1.2.2?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>release</td>
+    </tr>
+    <tr>
+		<td>Security-Critical</td>
+      	<td>sonatype-2019-0115</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:a-name/org.webjars%20jquery@1.10.2</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>release</td>
+    </tr>
+    <tr>
+		<td>Security-Critical</td>
+      	<td>sonatype-2015-0002</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/apache-collections/commons-collections@3.1?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>release</td>
+    </tr>
+    <tr>
+		<td>Security-Critical</td>
+      	<td>CVE-2017-7525</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.0.4?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>release</td>
+    </tr>
+    <tr>
+		<td>Security-Critical</td>
+      	<td>CVE-2018-1270</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/org.springframework/spring-expression@3.2.4.RELEASE?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>release</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2020-7238</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>release</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>sonatype-2020-0029</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>release</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2015-0254</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/javax.servlet/jstl@1.2?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>release</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2019-0227</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/axis/axis@1.2?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>release</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2015-0254</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/apache-taglibs/standard@1.1.2?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>release</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>CVE-2014-0114</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/commons-beanutils/commons-beanutils@1.6?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>release</td>
+    </tr>
+    <tr>
+		<td>Security-High</td>
+      	<td>sonatype-2017-0355</td>
+      	<td>Webgoat-legacy</td>
+      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-core@2.0.4?type=jar</td>
+		<td>2020-09-17 00:00:00</td>
+		<td>release</td>
+    </tr>
+    </tbody>
+    </table>
+    
+</div>
+</div>
+</div>
+</div>
+</div>
 <br><br>
 
 <div> 
@@ -224,3774 +4894,6 @@
 	</tr>
     </thead>
     <tbody>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-25287</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-25288</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-34552</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
-		<td>2021-07-20 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_x86_64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_i686</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-macosx_10_10_x86_64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win_amd64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win32</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-7212</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/urllib3@1.25.2?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-macosx_10_10_x86_64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-7212</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/urllib3@1.25.2?extension=tar.gz</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_i686</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_i686</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_i686</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_i686</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux2014_aarch64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-manylinux2010_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-manylinux2010_x86_64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-manylinux2010_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-manylinux2010_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-manylinux2010_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-manylinux2010_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-macosx_10_10_x86_64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win_amd64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_x86_64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux1_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35654</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-25291</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-25293</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28676</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=tar.gz</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-win32</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=pp36-pypy36_pp73-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win32</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_10_x86_64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_10_x86_64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux2014_aarch64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_10_intel</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_10_intel</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_10_intel</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_10_intel</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_10_intel</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_10_intel</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux2014_aarch64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp38-cp38-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35653</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23437</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux2014_aarch64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27921</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27922</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27923</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-28677</td>
-      	<td>chesscom__cmorenoserrano</td>
-      	<td>pkg:pypi/pillow@7.2.0?extension=whl&amp;qualifier=cp37-cp37m-manylinux2014_aarch64</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2018-20060</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/urllib3@1.22?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-7525</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.6.1?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp34-cp34m-win32</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2018-20060</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@15.1.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win-amd64-py2.7</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win-amd64-py2.6</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-16764</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django-make-app@0.1.3?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp27-cp27m-win32</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.11?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-17495</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:a-name/org.webjars%20swagger-ui@3.18.1</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win32-py3.2</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win32-py3.1</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py2-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2018-20060</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py2-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp27-cp27m-win32</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-12791</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-5200</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-7893</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2018-15751</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-17361</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-11651</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-25592</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-25281</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-25282</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-25283</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-3197</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>sonatype-2020-1057</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2018-20060</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/botocore@1.10.70?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-16764</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django-make-app@0.1.3?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_9_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-16616</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyanyapi@0.6.0?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>sonatype-2018-0010</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyanyapi@0.6.0?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>sonatype-2020-0149</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/codecov@2.0.15?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp35-cp35m-macosx_10_6_intel</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp27-cp27m-win_amd64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp34-cp34m-manylinux1_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2018-20060</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21344</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21345</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21346</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21347</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21350</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.11?extension=zip</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win32-py3.4</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2014-0474</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2016-9013</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-19844</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2018-20060</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/botocore@1.10.70?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win-amd64-py3.2</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp35-cp35m-win32</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp27-cp27mu-manylinux1_i686</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>sonatype-2015-0002</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/commons-collections/commons-collections@3.2.1?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2014-0474</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2016-9013</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-19844</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2018-20060</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-16618</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/owlmixin@1.2.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp34-cp34m-macosx_10_6_intel</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>sonatype-2020-0988</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:a-name/datatables@1.10.9</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2018-20060</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@15.1.0?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp27-cp27m-manylinux1_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win-amd64-py3.4</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_i686</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp27-cp27m-macosx_10_9_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2018-20060</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/urllib3@1.22?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2013-7459</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pycrypto@2.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-16763</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/confire@0.2.0?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp36-cp36m-manylinux1_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp37-cp37m-macosx_10_9_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-16616</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyanyapi@0.6.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>sonatype-2018-0010</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyanyapi@0.6.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp27-cp27m-win_amd64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win32-py2.7</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.12?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win32-py3.3</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp37-cp37m-win32</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp37-cp37m-manylinux1_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-0899</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/rubygems-update@1.4.1?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp36-cp36m-win32</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp35-cp35m-win_amd64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp36-cp36m-win_amd64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp37-cp37m-win_amd64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp34-cp34m-win_amd64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win-amd64-py3.1</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win32-py2.6</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp27-cp27mu-manylinux1_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-0230</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-core@2.5.12?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-17530</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-core@2.5.12?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-18342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyyaml@3.11?extension=exe&amp;qualifier=win-amd64-py3.3</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-13091</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pandas@0.22.0?extension=whl&amp;qualifier=cp35-cp35m-manylinux1_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-10683</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>sonatype-2015-0002</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-20478</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/ruamel.yaml@0.15.67?extension=whl&amp;qualifier=cp27-cp27mu-manylinux1_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-7525</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2019-0230</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2020-17530</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21342</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21344</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21345</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21346</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21347</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21350</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>sonatype-2015-0002</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>License-Banned</td>
-      	<td>CC-BY-NC-SA-4.0</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/safety-db@2017.4.19?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>License-Banned</td>
-      	<td>Proprietary-Clause</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.sonatype.nexus/nexus-platform-api@1.8.20171120-150856.6c36986?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>License-Banned</td>
-      	<td>AGPL-3.0</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyfsmlib@1.0?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>License-Banned</td>
-      	<td>AGPL-3.0</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyhwp@0.1b9?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>License-Banned</td>
-      	<td>CC-BY-NC-SA-4.0</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/safety-db@2017.4.19?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-11324</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/urllib3@1.22?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/matplotlib@1.3.1?extension=whl&amp;qualifier=cp33-cp33m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2017-17042</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/yard@0.8.7?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/yard@0.8.7?platform=ruby</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0309</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/yard@0.8.7?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-15560</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pycryptodome@3.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/simplecov-html@0.7.1?platform=ruby</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-18074</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@15.1.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-20225</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@15.1.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-20907</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@15.1.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-20916</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@15.1.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2012-0071</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@15.1.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-15560</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pycryptodome@3.6.1?extension=whl&amp;qualifier=cp27-cp27mu-manylinux1_x86_64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0866</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/lxml@4.1.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27291</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pygments@2.2.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2020-1357</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pygments@2.2.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-15560</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pycryptodome@3.6.1?extension=whl&amp;qualifier=cp27-cp27m-macosx_10_6_intel</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-18074</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py2-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-10906</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py2-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-11324</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py2-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-20907</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py2-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27291</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pygments@2.1.2?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2020-1357</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pygments@2.1.2?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-15560</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pycryptodome@3.6.1?extension=whl&amp;qualifier=cp27-cp27m-win32</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-28243</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-35662</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-21996</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-09-20 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-31607</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/salt@2016.11.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-18074</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/botocore@1.10.70?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2014-0038</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:npm/shelljs@0.3.0</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pyobjc-core@2.5.1?extension=tar.gz</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-10800</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/codecov@2.0.15?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2016-10745</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/jinja2@2.5.4?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-10906</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/jinja2@2.5.4?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/jinja2@2.5.4?extension=tar.gz</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-18074</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pip@18.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-20225</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pip@18.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-20907</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pip@18.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-20916</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pip@18.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2012-0071</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pip@18.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-14322</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/werkzeug@0.14.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-14806</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/werkzeug@0.14.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-18074</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-10906</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-11324</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-20907</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2016-3674</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2017-7957</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-26217</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-26258</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-21343</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-21348</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-21349</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.8?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-18074</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/requests@2.18.4?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2014-3483</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/activerecord@4.0.0?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2014-3514</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/activerecord@4.0.0?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2017-17916</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/activerecord@4.0.0?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2017-17917</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/activerecord@4.0.0?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2017-17919</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/activerecord@4.0.0?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2017-17920</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/activerecord@4.0.0?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-22880</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/activerecord@4.0.0?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2014-10077</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/i18n@0.6.4?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0866</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/lxml@4.2.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2015-5143</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2015-5145</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2016-2512</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2016-7401</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2016-9014</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-14232</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-14235</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-24584</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-31542</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-33571</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-13757</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/rsa@3.4.2?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/py2app@0.7.3?extension=tar.gz</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-18074</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/botocore@1.10.70?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2015-5143</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2015-5145</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2016-2512</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2016-7401</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2016-9014</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-14232</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-14235</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-24584</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-31542</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-33571</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/django@1.6.1?extension=tar.gz</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-14322</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/werkzeug@0.14.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-14806</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/werkzeug@0.14.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2014-0114</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/commons-beanutils/commons-beanutils@1.9.2?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-18074</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-10906</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-11324</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-20907</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pipenv@2018.7.1?extension=whl&amp;qualifier=py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2017-0355</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-core@2.6.1?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-18074</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@15.1.0?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-20225</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@15.1.0?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-20907</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@15.1.0?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-20916</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@15.1.0?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2012-0071</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@15.1.0?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2017-9805</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-plugin@2.5.12?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-11776</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-plugin@2.5.12?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-1327</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-plugin@2.5.12?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-1000656</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/flask@0.6?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-1010083</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/flask@0.6?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/aruba@0.5.3?platform=ruby</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-11324</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/urllib3@1.22?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-6594</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pycrypto@2.6.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/modulegraph@0.10.4?extension=tar.gz</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/cucumber@1.2.5?platform=ruby</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/safety-db@2017.4.19?extension=tar.gz</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-20225</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pip@10.0.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-20907</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pip@10.0.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-20916</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pip@10.0.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2012-0071</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pip@10.0.1?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/matplotlib@1.3.1?extension=whl&amp;qualifier=cp34-cp34m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2014-0114</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/commons-beanutils/commons-beanutils@1.9.3?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27291</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pygments@2.1.2?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2013-0069</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pygments@2.1.2?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pygments@2.1.2?extension=tar.gz</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2020-1357</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pygments@2.1.2?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-13757</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/rsa@3.4.2?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0870</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.freemarker/freemarker@2.3.23?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/macholib@1.5.1?extension=tar.gz</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/matplotlib@1.3.1?extension=whl&amp;qualifier=cp27-none-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:a-name/jquery@3.3.1</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-8320</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/rubygems-update@1.4.1?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-8321</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/rubygems-update@1.4.1?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-8322</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/rubygems-update@1.4.1?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-8323</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/rubygems-update@1.4.1?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-8325</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/rubygems-update@1.4.1?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2021-0729</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/rubygems-update@1.4.1?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-20225</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@16.0.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-20907</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@16.0.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-20916</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@16.0.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2012-0071</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/virtualenv@16.0.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:a-name/jQuery@1.8.0</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-29651</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/py@1.7.0?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/altgraph@0.10.2?extension=tar.gz</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-15560</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/pycryptodome@3.6.1?extension=whl&amp;qualifier=cp27-cp27m-win_amd64</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2013-1424</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/matplotlib@1.3.1?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/matplotlib@1.3.1?extension=tar.gz</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-1000201</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:gem/ffi@1.9.0?platform=ruby</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:npm/jquery-ui@1.12.1</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-10906</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/jinja2@2.10?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:a-name/jquery@2.1.3</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2017-9804</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-core@2.5.12?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-11776</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-core@2.5.12?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-0233</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-core@2.5.12?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-18074</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:pypi/requests@2.18.4?extension=tar.gz</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2012-0881</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2013-4002</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2016-1000338</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2016-1000343</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-1000632</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-0231</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.directory.server/apacheds-all@1.5.7?type=jar</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2014-0114</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2016-3674</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2017-7957</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2017-9804</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2017-9805</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-11776</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2018-1327</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-0233</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-26217</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-26258</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-21343</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-21348</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-21349</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2017-0355</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0870</td>
-      	<td>se-scripts__cmorenoserrano</td>
-      	<td>pkg:maven/org.apache.struts/struts2-rest-showcase@2.5.12?type=war</td>
-		<td>2021-08-29 00:00:00</td>
-		<td>source</td>
-    </tr>
     <tr>
 		<td>Security-Critical</td>
       	<td>CVE-2020-10683</td>
@@ -4026,62 +4928,6 @@
     </tr>
     <tr>
 		<td>Security-Critical</td>
-      	<td>CVE-2021-21342</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21344</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21345</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21346</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21347</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21350</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-5929</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/ch.qos.logback/logback-classic@1.1.11?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
       	<td>CVE-2017-0899</td>
       	<td>SecretSauce</td>
       	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
@@ -4094,30 +4940,6 @@
       	<td>SecretSauce</td>
       	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
 		<td>2019-11-20 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-37714</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/org.jsoup/jsoup@1.11.3?type=jar</td>
-		<td>2021-08-27 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:a-name/org.webjars%20jquery@1.10.2</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-22112</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/org.springframework.security/spring-security-web@4.2.10.RELEASE?type=jar</td>
-		<td>2021-03-04 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -4170,34 +4992,10 @@
     </tr>
     <tr>
 		<td>Security-High</td>
-      	<td>CVE-2020-25649</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.11.3?type=jar</td>
-		<td>2020-12-10 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
       	<td>sonatype-2017-0312</td>
       	<td>SecretSauce</td>
       	<td>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.11.3?type=jar</td>
 		<td>2019-11-20 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2021-1175</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/ch.qos.logback/logback-core@1.1.11?type=jar</td>
-		<td>2021-09-20 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:a-name/jQuery@1.6.4</td>
-		<td>2021-09-07 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -4242,42 +5040,10 @@
     </tr>
     <tr>
 		<td>Security-High</td>
-      	<td>CVE-2020-17527</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.35?type=jar</td>
-		<td>2020-12-10 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
       	<td>CVE-2020-9484</td>
       	<td>SecretSauce</td>
       	<td>pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.35?type=jar</td>
 		<td>2020-06-08 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-25122</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.35?type=jar</td>
-		<td>2021-03-09 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-41079</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.35?type=jar</td>
-		<td>2021-09-20 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23358</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:a-name/underscore@1.7.0</td>
-		<td>2021-07-07 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -4302,46 +5068,6 @@
       	<td>SecretSauce</td>
       	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
 		<td>2020-06-08 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-26217</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2020-12-06 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-26258</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2020-12-18 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-21343</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-21348</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-21349</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-04-01 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -4390,14 +5116,6 @@
       	<td>SecretSauce</td>
       	<td>pkg:maven/org.bouncycastle/bcprov-jdk15on@1.50?type=jar</td>
 		<td>2020-06-03 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:a-name/jquery@2.2.4</td>
-		<td>2021-09-07 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -4506,58 +5224,10 @@
     </tr>
     <tr>
 		<td>Security-High</td>
-      	<td>CVE-2020-25613</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
-		<td>2020-10-22 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-31799</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
-		<td>2021-08-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
       	<td>sonatype-2013-0080</td>
       	<td>SecretSauce</td>
       	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
 		<td>2019-11-20 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2021-0729</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
-		<td>2021-06-29 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2021-1118</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
-		<td>2021-09-11 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-25638</td>
-      	<td>SecretSauce</td>
-      	<td>pkg:maven/org.hibernate/hibernate-core@5.0.12.Final?type=jar</td>
-		<td>2020-11-20 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -4583,22 +5253,6 @@
       	<td>pkg:maven/org.asciidoctor/asciidoctorj@1.5.4?type=jar</td>
 		<td>2019-11-20 00:00:00</td>
 		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-33503</td>
-      	<td>success-metrics__cmorenoserrano</td>
-      	<td>pkg:pypi/urllib3@1.25.8?extension=tar.gz</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-33503</td>
-      	<td>success-metrics__cmorenoserrano</td>
-      	<td>pkg:pypi/urllib3@1.25.8?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-07-19 00:00:00</td>
-		<td>source</td>
     </tr>
     <tr>
 		<td>Security-Critical</td>
@@ -4794,14 +5448,6 @@
     </tr>
     <tr>
 		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>Successmetrics</td>
-      	<td>pkg:pypi/tables@3.5.2?extension=tar.gz</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
       	<td>CVE-2020-7212</td>
       	<td>Successmetrics</td>
       	<td>pkg:pypi/urllib3@1.25.2?extension=whl&amp;qualifier=py2.py3-none-any</td>
@@ -4814,38 +5460,6 @@
       	<td>Successmetrics</td>
       	<td>pkg:pypi/urllib3@1.25.2?extension=tar.gz</td>
 		<td>2020-03-14 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27291</td>
-      	<td>Successmetrics</td>
-      	<td>pkg:pypi/pygments@2.4.2?extension=tar.gz</td>
-		<td>2021-03-26 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2020-1357</td>
-      	<td>Successmetrics</td>
-      	<td>pkg:pypi/pygments@2.4.2?extension=tar.gz</td>
-		<td>2021-02-05 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-27291</td>
-      	<td>Successmetrics</td>
-      	<td>pkg:pypi/pygments@2.4.2?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-03-26 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2020-1357</td>
-      	<td>Successmetrics</td>
-      	<td>pkg:pypi/pygments@2.4.2?extension=whl&amp;qualifier=py2.py3-none-any</td>
-		<td>2021-02-05 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -4882,62 +5496,6 @@
     </tr>
     <tr>
 		<td>Security-Critical</td>
-      	<td>CVE-2021-21342</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21344</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21345</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21346</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21347</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2021-21350</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-5929</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/ch.qos.logback/logback-classic@1.1.11?type=jar</td>
-		<td>2021-08-24 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
       	<td>CVE-2017-0899</td>
       	<td>TechEnablement</td>
       	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
@@ -4950,30 +5508,6 @@
       	<td>TechEnablement</td>
       	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
 		<td>2019-09-09 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-37714</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/org.jsoup/jsoup@1.11.3?type=jar</td>
-		<td>2021-08-27 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:a-name/org.webjars%20jquery@1.10.2</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-22112</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/org.springframework.security/spring-security-web@4.2.10.RELEASE?type=jar</td>
-		<td>2021-03-04 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -5018,34 +5552,10 @@
     </tr>
     <tr>
 		<td>Security-High</td>
-      	<td>CVE-2020-25649</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.11.3?type=jar</td>
-		<td>2020-12-10 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
       	<td>sonatype-2017-0312</td>
       	<td>TechEnablement</td>
       	<td>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.11.3?type=jar</td>
 		<td>2019-09-09 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2021-1175</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/ch.qos.logback/logback-core@1.1.11?type=jar</td>
-		<td>2021-09-20 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:a-name/jQuery@1.6.4</td>
-		<td>2021-09-07 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -5090,42 +5600,10 @@
     </tr>
     <tr>
 		<td>Security-High</td>
-      	<td>CVE-2020-17527</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.35?type=jar</td>
-		<td>2020-12-10 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
       	<td>CVE-2020-9484</td>
       	<td>TechEnablement</td>
       	<td>pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.35?type=jar</td>
 		<td>2020-06-08 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-25122</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.35?type=jar</td>
-		<td>2021-03-09 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-41079</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@8.5.35?type=jar</td>
-		<td>2021-09-20 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-23358</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:a-name/underscore@1.7.0</td>
-		<td>2021-07-07 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -5150,46 +5628,6 @@
       	<td>TechEnablement</td>
       	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
 		<td>2019-09-09 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-26217</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2020-12-06 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-26258</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2020-12-18 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-21343</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-21348</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-03-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-21349</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/com.thoughtworks.xstream/xstream@1.4.7?type=jar</td>
-		<td>2021-04-01 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -5238,14 +5676,6 @@
       	<td>TechEnablement</td>
       	<td>pkg:maven/org.bouncycastle/bcprov-jdk15on@1.50?type=jar</td>
 		<td>2020-06-03 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:a-name/jquery@2.2.4</td>
-		<td>2021-09-07 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -5354,58 +5784,10 @@
     </tr>
     <tr>
 		<td>Security-High</td>
-      	<td>CVE-2020-25613</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
-		<td>2020-10-22 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-31799</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
-		<td>2021-08-28 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
       	<td>sonatype-2013-0080</td>
       	<td>TechEnablement</td>
       	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
 		<td>2019-09-09 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2021-0729</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
-		<td>2021-06-29 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2021-1118</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/org.jruby/jruby-complete@1.7.21?type=jar</td>
-		<td>2021-09-11 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-25638</td>
-      	<td>TechEnablement</td>
-      	<td>pkg:maven/org.hibernate/hibernate-core@5.0.12.Final?type=jar</td>
-		<td>2020-11-20 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -5498,14 +5880,6 @@
     </tr>
     <tr>
 		<td>Security-Critical</td>
-      	<td>CVE-2019-17571</td>
-      	<td>TradingApp</td>
-      	<td>pkg:maven/log4j/log4j@1.2.17?type=jar</td>
-		<td>2021-06-14 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
       	<td>CVE-2016-1000027</td>
       	<td>TradingApp</td>
       	<td>pkg:maven/org.springframework/spring-web@3.2.4.RELEASE?type=jar</td>
@@ -5546,14 +5920,6 @@
     </tr>
     <tr>
 		<td>Security-High</td>
-      	<td>CVE-2021-22112</td>
-      	<td>TradingApp</td>
-      	<td>pkg:maven/org.springframework.security/spring-security-web@3.2.4.RELEASE?type=jar</td>
-		<td>2021-03-04 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
       	<td>sonatype-2017-0641</td>
       	<td>TradingApp</td>
       	<td>pkg:maven/org.springframework.security/spring-security-web@3.2.4.RELEASE?type=jar</td>
@@ -5582,14 +5948,6 @@
       	<td>TradingApp</td>
       	<td>pkg:maven/commons-fileupload/commons-fileupload@1.2.2?type=jar</td>
 		<td>2020-06-08 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>TradingApp</td>
-      	<td>pkg:a-name/org.webjars%20jquery@1.10.2</td>
-		<td>2021-09-07 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -5770,50 +6128,10 @@
     </tr>
     <tr>
 		<td>Security-High</td>
-      	<td>CVE-2021-22118</td>
-      	<td>TradingApp</td>
-      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
-		<td>2021-06-14 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-37136</td>
-      	<td>TradingApp</td>
-      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
-		<td>2021-09-14 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
       	<td>sonatype-2020-0029</td>
       	<td>TradingApp</td>
       	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
 		<td>2020-03-07 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2020-1031</td>
-      	<td>TradingApp</td>
-      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
-		<td>2020-10-30 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2021-0789</td>
-      	<td>TradingApp</td>
-      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
-		<td>2021-07-08 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2010-0053</td>
-      	<td>TradingApp</td>
-      	<td>pkg:maven/log4j/log4j@1.2.17?type=jar</td>
-		<td>2021-06-14 00:00:00</td>
 		<td>build</td>
     </tr>
     <tr>
@@ -5897,46 +6215,6 @@
 		<td>build</td>
     </tr>
     <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2016-1000031</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/commons-fileupload/commons-fileupload@1.2.2?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>sonatype-2015-0002</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/apache-collections/commons-collections@3.1?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-7525</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.0.4?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2018-1270</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/org.springframework/spring-expression@3.2.4.RELEASE?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-22112</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/org.springframework.security/spring-security-web@3.2.4.RELEASE?type=jar</td>
-		<td>2021-03-04 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
 		<td>Security-High</td>
       	<td>CVE-2020-13935</td>
       	<td>Webgoat-legacy</td>
@@ -5946,211 +6224,11 @@
     </tr>
     <tr>
 		<td>Security-High</td>
-      	<td>CVE-2020-7238</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
       	<td>CVE-2020-9484</td>
       	<td>Webgoat-legacy</td>
       	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
 		<td>2020-06-08 00:00:00</td>
 		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-22118</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
-		<td>2021-06-14 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2021-37136</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
-		<td>2021-09-14 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2020-0029</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2020-1031</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
-		<td>2020-10-30 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2021-0789</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
-		<td>2021-07-08 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:a-name/org.webjars%20jquery@1.10.2</td>
-		<td>2021-09-07 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2010-0053</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/log4j/log4j@1.2.17?type=jar</td>
-		<td>2021-06-14 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2015-0254</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/javax.servlet/jstl@1.2?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-0227</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/axis/axis@1.2?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2015-0254</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/apache-taglibs/standard@1.1.2?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2014-0114</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/commons-beanutils/commons-beanutils@1.6?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2017-0355</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-core@2.0.4?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>build</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2016-1000031</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/commons-fileupload/commons-fileupload@1.2.2?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>release</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>sonatype-2019-0115</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:a-name/org.webjars%20jquery@1.10.2</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>release</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>sonatype-2015-0002</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/apache-collections/commons-collections@3.1?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>release</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2017-7525</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.0.4?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>release</td>
-    </tr>
-    <tr>
-		<td>Security-Critical</td>
-      	<td>CVE-2018-1270</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/org.springframework/spring-expression@3.2.4.RELEASE?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>release</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2020-7238</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>release</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2020-0029</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/org.apache.activemq.examples.modules/artemis-tomcat-jndi-resources-sample@2.11.0?classifier=exec-war&amp;type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>release</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2015-0254</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/javax.servlet/jstl@1.2?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>release</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2019-0227</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/axis/axis@1.2?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>release</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2015-0254</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/apache-taglibs/standard@1.1.2?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>release</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>CVE-2014-0114</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/commons-beanutils/commons-beanutils@1.6?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>release</td>
-    </tr>
-    <tr>
-		<td>Security-High</td>
-      	<td>sonatype-2017-0355</td>
-      	<td>Webgoat-legacy</td>
-      	<td>pkg:maven/com.fasterxml.jackson.core/jackson-core@2.0.4?type=jar</td>
-		<td>2020-09-17 00:00:00</td>
-		<td>release</td>
     </tr>
     </tbody>
     </table>


### PR DESCRIPTION
Web reports at /violationsage and /evaluations use the current date to work out how old issues are. This causes problems for testing where we need a deterministic output. Specifically because the HTML of these pages changes based on when they are run.

This PR adds the option to specify the date to /violationsage and /evaluations by adding ?date=2021-12-15 to the URL (for example). This date will then be used as the basis for age calculations on those pages. Tests of these pages are update to use specific dates to ensure deterministic results, test cases have been updated to reflect this.