### PR TITLE
Update risk ratio calculation

### DIFF
--- a/src/main/java/org/sonatype/cs/metrics/service/ApplicationsDataService.java
+++ b/src/main/java/org/sonatype/cs/metrics/service/ApplicationsDataService.java
@@ -133,6 +133,7 @@ public class ApplicationsDataService {
 		List<DbRow> riskRatio = dbService.runSql(tableName, SqlStatements.RiskRatio);
 		model.put("riskRatioChart", riskRatio);
 		model.put("riskRatioAtEndPeriod", riskRatio.get(riskRatio.size() - 1).getPointA());
+		model.put("riskRatioAtStartPeriod", riskRatio.get(0).getPointA());
 
 		return model;
 	}

--- a/src/main/java/org/sonatype/cs/metrics/service/InsightsAnalysisService.java
+++ b/src/main/java/org/sonatype/cs/metrics/service/InsightsAnalysisService.java
@@ -144,7 +144,7 @@ public class InsightsAnalysisService {
 	    model.put("backlogReductionCriticalsRate", this.calculateChangePctg(backlogReductionCriticalsRateBefore, backlogReductionCriticalsRateAfter));
 	    model.put("backlogReductionCriticalsRateIncrease", this.calculateChangeMultiple(backlogReductionCriticalsRateBefore, backlogReductionCriticalsRateAfter));
 
-	    float riskRatioBefore = Integer.parseInt(String.valueOf(p1metrics.get("riskRatioAtEndPeriod")));
+		float riskRatioBefore = Integer.parseInt(String.valueOf(p1metrics.get("riskRatioAtStartPeriod")));
 	    float riskRatioAfter = Integer.parseInt(String.valueOf(p2metrics.get("riskRatioAtEndPeriod")));
 	    
 	    model.put("riskRatioBefore", riskRatioBefore);

--- a/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsIsightsApplicationTestTo202106.checkCSVFileIsGenerated.approved.txt
+++ b/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsIsightsApplicationTestTo202106.checkCSVFileIsGenerated.approved.txt
@@ -8,5 +8,5 @@ Average Scans per App (scanning rate/apps),5.27,1.39,-3.87,-73.56,0.26
 Discovery Rate Criticals (# of discovered Critical violations/period & app),11.51,5.89,-5.62,-48.85,0.51
 Fixing Rate Criticals (# of fixed Critical violations/period & app),2.91,0.98,-1.93,-66.29,0.34
 Backlog Reduction Rate Criticals %(# of fixed / # of discovered),59.39,16.75,-42.65,-71.80,0.28
-Risk Ratio (# of Critical violations / # of apps),25.0,20.0,-5.00,-20.00,0.80
+Risk Ratio (# of Critical violations / # of apps),24.0,20.0,-4.00,-16.67,0.83
 MTTR Criticals (average # of days to fix Critical violations),22,28,6.00,27.27,1.27

--- a/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsIsightsApplicationTestTo202107.checkCSVFileIsGenerated.approved.txt
+++ b/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsIsightsApplicationTestTo202107.checkCSVFileIsGenerated.approved.txt
@@ -8,5 +8,5 @@ Average Scans per App (scanning rate/apps),5.27,1.16,-4.11,-78.05,0.22
 Discovery Rate Criticals (# of discovered Critical violations/period & app),11.51,3.93,-7.58,-65.86,0.34
 Fixing Rate Criticals (# of fixed Critical violations/period & app),2.91,0.57,-2.34,-80.41,0.20
 Backlog Reduction Rate Criticals %(# of fixed / # of discovered),59.39,12.67,-46.72,-78.66,0.21
-Risk Ratio (# of Critical violations / # of apps),25.0,20.0,-5.00,-20.00,0.80
+Risk Ratio (# of Critical violations / # of apps),24.0,20.0,-4.00,-16.67,0.83
 MTTR Criticals (average # of days to fix Critical violations),22,36,14.00,63.64,1.64


### PR DESCRIPTION
The basis of the risk ratio calculation will now be a comparison between the
start of the first period and the end of the second. Previously the comparison
was done between the end of each period.﻿
