### PR TITLE
Move pages to have html suffix

### DIFF
--- a/src/main/java/org/sonatype/cs/metrics/controller/ApplicationEvaluationsController.java
+++ b/src/main/java/org/sonatype/cs/metrics/controller/ApplicationEvaluationsController.java
@@ -25,7 +25,7 @@ public class ApplicationEvaluationsController {
 
     @Autowired private HelperService helperService;
 
-    @GetMapping({"/evaluations"})
+    @GetMapping({"/evaluations", "/evaluations.html"})
     public String applicationEvaluations(
             Model model, @RequestParam(name = "date", required = false) String comparisonDate) {
 

--- a/src/main/java/org/sonatype/cs/metrics/controller/ApplicationsController.java
+++ b/src/main/java/org/sonatype/cs/metrics/controller/ApplicationsController.java
@@ -21,7 +21,7 @@ public class ApplicationsController {
 
     @Autowired private ApplicationsDataService applicationsDataService;
 
-    @GetMapping({"/applications"})
+    @GetMapping({"/applications", "/applications.html"})
     public String applications(Model model) throws ParseException {
 
         log.info("In ApplicationsController");

--- a/src/main/java/org/sonatype/cs/metrics/controller/ApplicationsSummaryController.java
+++ b/src/main/java/org/sonatype/cs/metrics/controller/ApplicationsSummaryController.java
@@ -28,7 +28,7 @@ public class ApplicationsSummaryController {
 
     @Autowired private ApplicationsDataService applicationsDataService;
 
-    @GetMapping({"/appsummary"})
+    @GetMapping({"/appsummary", "/appsummary.html"})
     public String application(
             Model model,
             @RequestParam(value = "appname", defaultValue = "none") String applicationName)

--- a/src/main/java/org/sonatype/cs/metrics/controller/ComparePeriodsController.java
+++ b/src/main/java/org/sonatype/cs/metrics/controller/ComparePeriodsController.java
@@ -22,7 +22,7 @@ public class ComparePeriodsController {
 
     @Autowired private MetricsService metricsService;
 
-    @GetMapping({"/compare"})
+    @GetMapping({"/compare", "/compare.html"})
     public String applications(Model model) throws ParseException {
         log.info("In ComparePeriodsController");
 

--- a/src/main/java/org/sonatype/cs/metrics/controller/ComponentWaiversController.java
+++ b/src/main/java/org/sonatype/cs/metrics/controller/ComponentWaiversController.java
@@ -19,7 +19,7 @@ public class ComponentWaiversController {
 
     @Autowired private DbService dbService;
 
-    @GetMapping({"/waivers"})
+    @GetMapping({"/waivers", "/waivers.html"})
     public String componentWaivers(Model model) {
 
         log.info("In ComponentWaiversController");

--- a/src/main/java/org/sonatype/cs/metrics/controller/FirewallController.java
+++ b/src/main/java/org/sonatype/cs/metrics/controller/FirewallController.java
@@ -30,7 +30,7 @@ public class FirewallController {
     @Value("${data.dir}")
     private String dataDir;
 
-    @GetMapping({"/firewall"})
+    @GetMapping({"/firewall", "/firewall.html"})
     public String firewall(Model model) throws IOException {
         log.info("In FirewallController");
 

--- a/src/main/java/org/sonatype/cs/metrics/controller/HomeController.java
+++ b/src/main/java/org/sonatype/cs/metrics/controller/HomeController.java
@@ -20,7 +20,7 @@ public class HomeController {
     @Value("${sm.database}")
     private String smdatabase;
 
-    @GetMapping({"/", "/home"})
+    @GetMapping({"/", "/home", "/home.html"})
     public String home(Model model) {
 
         log.info("In HomeController");

--- a/src/main/java/org/sonatype/cs/metrics/controller/InsightsAnalysisController.java
+++ b/src/main/java/org/sonatype/cs/metrics/controller/InsightsAnalysisController.java
@@ -22,7 +22,7 @@ public class InsightsAnalysisController {
 
     @Autowired private PeriodsDataService periodsDataService;
 
-    @GetMapping({"/analysis"})
+    @GetMapping({"/analysis", "/analysis.html"})
     public String analysis(Model model) throws ParseException {
         log.info("In InsightsAnalysisController");
 

--- a/src/main/java/org/sonatype/cs/metrics/controller/LicenseViolationsController.java
+++ b/src/main/java/org/sonatype/cs/metrics/controller/LicenseViolationsController.java
@@ -24,7 +24,7 @@ public class LicenseViolationsController {
 
     @Autowired private ApplicationsDataService applicationsDataService;
 
-    @GetMapping({"/licenseviolations"})
+    @GetMapping({"/licenseviolations", "/licenseviolations.html"})
     public String licenseViolations(Model model) throws ParseException {
 
         log.info("In LicenseViolationsController");

--- a/src/main/java/org/sonatype/cs/metrics/controller/PolicyViolationsAgeController.java
+++ b/src/main/java/org/sonatype/cs/metrics/controller/PolicyViolationsAgeController.java
@@ -24,7 +24,7 @@ public class PolicyViolationsAgeController {
 
     @Autowired private HelperService helperService;
 
-    @GetMapping({"/violationsage"})
+    @GetMapping({"/violationsage", "/violationsage.html"})
     public String policyViolationsAge(
             Model model, @RequestParam(name = "date", required = false) String comparisonDate) {
 

--- a/src/main/java/org/sonatype/cs/metrics/controller/SecurityViolationsController.java
+++ b/src/main/java/org/sonatype/cs/metrics/controller/SecurityViolationsController.java
@@ -24,7 +24,7 @@ public class SecurityViolationsController {
 
     @Autowired private ApplicationsDataService applicationsDataService;
 
-    @GetMapping({"/securityviolations"})
+    @GetMapping({"/securityviolations", "/securityviolations.html"})
     public String securityViolations(Model model) throws ParseException {
 
         log.info("In SecurityViolationsController");

--- a/src/main/java/org/sonatype/cs/metrics/controller/SummaryController.java
+++ b/src/main/java/org/sonatype/cs/metrics/controller/SummaryController.java
@@ -22,7 +22,7 @@ public class SummaryController {
 
     @Autowired private MetricsService metricsService;
 
-    @GetMapping({"/summary"})
+    @GetMapping({"/summary", "/summary.html"})
     public String applications(Model model) throws ParseException {
 
         log.info("In ReportSummaryController");

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -12,13 +12,13 @@
     	<div class="text-center">
 
     	<div th:if="${successmetricsreport}">
-    	<a th:href="@{summary}">Summary Report <em>(anonymised)</em></a>
+    	<a th:href="@{summary.html}">Summary Report <em>(anonymised)</em></a>
         <br><br>
-        <a th:href="@{applications}">Applications Report</a>
+        <a th:href="@{applications.html}">Applications Report</a>
         <br><br>
-        <a th:href="@{securityviolations}">Security Violations Report</a>
+        <a th:href="@{securityviolations.html}">Security Violations Report</a>
         <br><br>
-        <a th:href="@{licenseviolations}">License Violations Report</a>
+        <a th:href="@{licenseviolations.html}">License Violations Report</a>
         <br><br>
         <!--
 		<a th:href="@{analysis}">Insights Analysis Data</a>
@@ -27,22 +27,22 @@
         -->
 
 		<div th:if="${firewallreport}">
-		<a th:href="@{firewall}">Firewall Report</a>
+		<a th:href="@{firewall.html}">Firewall Report</a>
 		<br><br>
 		</div>
 
 	    <div th:if="${policyViolationsreport}">
-	    <a th:href="@{violationsage}">Policy Violations Report</a>
+	    <a th:href="@{violationsage.html}">Policy Violations Report</a>
 	    <br><br>
 	    </div>
 
 	    <div th:if="${applicationEvaluationsreport}">
-	    <a th:href="@{evaluations}">Application Evaluations Report</a>
+	    <a th:href="@{evaluations.html}">Application Evaluations Report</a>
 	    <br><br>
 		</div>
 
 		<div th:if="${componentWaiversReport}">
-		<a th:href="@{waivers}">Component Waivers Report</a>
+		<a th:href="@{waivers.html}">Component Waivers Report</a>
 		<br><br>
 		</div>
 

--- a/src/test/java/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.java
+++ b/src/test/java/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.java
@@ -47,6 +47,14 @@ public class SuccessMetricsWebApplicationTest {
                 this.restTemplate
                         .getForObject("http://localhost:" + port + "/", String.class)
                         .contains("Success Metrics"));
+        assertTrue(
+                this.restTemplate
+                        .getForObject("http://localhost:" + port + "/home", String.class)
+                        .contains("Success Metrics"));
+        assertTrue(
+                this.restTemplate
+                        .getForObject("http://localhost:" + port + "/home.html", String.class)
+                        .contains("Success Metrics"));
     }
 
     @Test
@@ -55,6 +63,10 @@ public class SuccessMetricsWebApplicationTest {
                 this.restTemplate
                         .getForObject("http://localhost:" + port + "/summary", String.class)
                         .contains("Summary Report"));
+        assertTrue(
+                this.restTemplate
+                        .getForObject("http://localhost:" + port + "/summary.html", String.class)
+                        .contains("Summary Report"));
     }
 
     @Test
@@ -62,6 +74,11 @@ public class SuccessMetricsWebApplicationTest {
         assertTrue(
                 this.restTemplate
                         .getForObject("http://localhost:" + port + "/applications", String.class)
+                        .contains("Applications Report"));
+        assertTrue(
+                this.restTemplate
+                        .getForObject(
+                                "http://localhost:" + port + "/applications.html", String.class)
                         .contains("Applications Report"));
     }
 
@@ -72,6 +89,12 @@ public class SuccessMetricsWebApplicationTest {
                         .getForObject(
                                 "http://localhost:" + port + "/securityviolations", String.class)
                         .contains("Security Violations Report"));
+        assertTrue(
+                this.restTemplate
+                        .getForObject(
+                                "http://localhost:" + port + "/securityviolations.html",
+                                String.class)
+                        .contains("Security Violations Report"));
     }
 
     @Test
@@ -81,6 +104,12 @@ public class SuccessMetricsWebApplicationTest {
                         .getForObject(
                                 "http://localhost:" + port + "/licenseviolations", String.class)
                         .contains("License Violations Report"));
+        assertTrue(
+                this.restTemplate
+                        .getForObject(
+                                "http://localhost:" + port + "/licenseviolations.html",
+                                String.class)
+                        .contains("License Violations Report"));
     }
 
     @Test
@@ -88,6 +117,11 @@ public class SuccessMetricsWebApplicationTest {
         assertTrue(
                 this.restTemplate
                         .getForObject("http://localhost:" + port + "/violationsage", String.class)
+                        .contains("Policy Violations Age"));
+        assertTrue(
+                this.restTemplate
+                        .getForObject(
+                                "http://localhost:" + port + "/violationsage.html", String.class)
                         .contains("Policy Violations Age"));
     }
 
@@ -97,6 +131,11 @@ public class SuccessMetricsWebApplicationTest {
                 this.restTemplate
                         .getForObject("http://localhost:" + port + "/evaluations", String.class)
                         .contains("Application Last Date Evaluated"));
+        assertTrue(
+                this.restTemplate
+                        .getForObject(
+                                "http://localhost:" + port + "/evaluations.html", String.class)
+                        .contains("Application Last Date Evaluated"));
     }
 
     @Test
@@ -104,6 +143,10 @@ public class SuccessMetricsWebApplicationTest {
         assertTrue(
                 this.restTemplate
                         .getForObject("http://localhost:" + port + "/waivers", String.class)
+                        .contains("Components Waivers Report"));
+        assertTrue(
+                this.restTemplate
+                        .getForObject("http://localhost:" + port + "/waivers.html", String.class)
                         .contains("Components Waivers Report"));
     }
 
@@ -119,7 +162,7 @@ public class SuccessMetricsWebApplicationTest {
     public void summaryPageContentTest() throws Exception {
         String pageContents =
                 this.restTemplate.getForObject(
-                        "http://localhost:" + port + "/summary", String.class);
+                        "http://localhost:" + port + "/summary.html", String.class);
         pageContents = removeLine(pageContents, 23);
         Approvals.verify(pageContents);
     }
@@ -128,7 +171,7 @@ public class SuccessMetricsWebApplicationTest {
     public void applicationsPageContentTest() throws Exception {
         String pageContents =
                 this.restTemplate.getForObject(
-                        "http://localhost:" + port + "/applications", String.class);
+                        "http://localhost:" + port + "/applications.html", String.class);
         pageContents = removeLine(pageContents, 23);
         Approvals.verify(pageContents);
     }
@@ -137,7 +180,7 @@ public class SuccessMetricsWebApplicationTest {
     public void securityViolationsPageContentTest() throws Exception {
         String pageContents =
                 this.restTemplate.getForObject(
-                        "http://localhost:" + port + "/securityviolations", String.class);
+                        "http://localhost:" + port + "/securityviolations.html", String.class);
         pageContents = removeLine(pageContents, 23);
         Approvals.verify(pageContents);
     }
@@ -146,7 +189,7 @@ public class SuccessMetricsWebApplicationTest {
     public void licenseViolationsPageContentTest() throws Exception {
         String pageContents =
                 this.restTemplate.getForObject(
-                        "http://localhost:" + port + "/licenseviolations", String.class);
+                        "http://localhost:" + port + "/licenseviolations.html", String.class);
         pageContents = removeLine(pageContents, 23);
         Approvals.verify(pageContents);
     }
@@ -155,7 +198,7 @@ public class SuccessMetricsWebApplicationTest {
     public void PolicyViolationsReportPageContentTest() throws Exception {
         String pageContents =
                 this.restTemplate.getForObject(
-                        "http://localhost:" + port + "/violationsage?date=2020-12-15",
+                        "http://localhost:" + port + "/violationsage.html?date=2020-12-15",
                         String.class);
         pageContents = removeLine(pageContents, 24);
         Approvals.verify(pageContents);
@@ -165,7 +208,8 @@ public class SuccessMetricsWebApplicationTest {
     public void ApplicationEvaluationsReportPageContentTest() throws Exception {
         String pageContents =
                 this.restTemplate.getForObject(
-                        "http://localhost:" + port + "/evaluations?date=2021-12-15", String.class);
+                        "http://localhost:" + port + "/evaluations.html?date=2021-12-15",
+                        String.class);
         pageContents = removeLine(pageContents, 23);
         Approvals.verify(pageContents);
     }
@@ -174,7 +218,7 @@ public class SuccessMetricsWebApplicationTest {
     public void ComponentWaiversReportPageContentTest() throws Exception {
         String pageContents =
                 this.restTemplate.getForObject(
-                        "http://localhost:" + port + "/waivers", String.class);
+                        "http://localhost:" + port + "/waivers.html", String.class);
         pageContents = removeLine(pageContents, 24);
         Approvals.verify(pageContents);
     }

--- a/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.defaultPageContentTest.approved.txt
+++ b/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.defaultPageContentTest.approved.txt
@@ -154,13 +154,13 @@
     	<div class="text-center">
 
     	<div>
-    	<a href="summary">Summary Report <em>(anonymised)</em></a>
+    	<a href="summary.html">Summary Report <em>(anonymised)</em></a>
         <br><br>
-        <a href="applications">Applications Report</a>
+        <a href="applications.html">Applications Report</a>
         <br><br>
-        <a href="securityviolations">Security Violations Report</a>
+        <a href="securityviolations.html">Security Violations Report</a>
         <br><br>
-        <a href="licenseviolations">License Violations Report</a>
+        <a href="licenseviolations.html">License Violations Report</a>
         <br><br>
         <!--
 		<a th:href="@{analysis}">Insights Analysis Data</a>
@@ -171,17 +171,17 @@
 		
 
 	    <div>
-	    <a href="violationsage">Policy Violations Report</a>
+	    <a href="violationsage.html">Policy Violations Report</a>
 	    <br><br>
 	    </div>
 
 	    <div>
-	    <a href="evaluations">Application Evaluations Report</a>
+	    <a href="evaluations.html">Application Evaluations Report</a>
 	    <br><br>
 		</div>
 
 		<div>
-		<a href="waivers">Component Waivers Report</a>
+		<a href="waivers.html">Component Waivers Report</a>
 		<br><br>
 		</div>
 


### PR DESCRIPTION
This PR ensures that web pages served by this application end in `.html`. This
change is made so that the contents of the web reports can be extracted 
programatically (for example using curl or wget) and then render correctly when
viewed as files locally on another device (for example a laptop). The aim is 
to improve user experience.

Existing links are left intact in case those are used in existing pipelines.
References from the root page `http://localhost:4040/` are update to point at
pages ending `.html`
