### PR TITLE
Only run pre-commit check on main branch

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -2,7 +2,9 @@ name: test-report-coverage
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   pre-commit:
@@ -17,7 +19,7 @@ jobs:
       - name: Print Python version
         run: python -V
       - name: Install pre-commit-checks
-        run:  pip install pre-commit==2.16.0
+        run: pip install pre-commit==2.16.0
       - name: Run pre-commit on all files
         run: pre-commit run --all-files
         continue-on-error: true
@@ -42,13 +44,13 @@ jobs:
           distribution: "adopt"
 
       - name: Build with Gradle
-        run:  |
-              # Strip git ref prefix from version
-              VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        run: |
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
-              # Strip "v" prefix from tag name
-              [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-              ./gradlew -Prelversion=$VERSION clean build test
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          ./gradlew -Prelversion=$VERSION clean build test
 
       - name: Generate JaCoCo Badge
         id: jacoco


### PR DESCRIPTION
The GitHub Pre-commit action does not work properly with updating files
when they are pushed from another (forked) repository. To address this
changes will only be made on PRs/pushes to the main branch.
