### PR TITLE
Fix issue with missing revision in release zip

### DIFF
--- a/.github/workflows/nexusiq-successmetrics.yml
+++ b/.github/workflows/nexusiq-successmetrics.yml
@@ -37,7 +37,13 @@ jobs:
             path: build/libs
 
         - name: Build release with Gradle
-          run: ./gradlew release
+          run: |
+              # Strip git ref prefix from version
+              VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+              # Strip "v" prefix from tag name
+              [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+              ./gradlew -Prelversion=$VERSION release
 
         - name: Create release
           uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Before this PR the successmetrics zip﻿file in each release is named
"successmetrics-undefined.zip", this is incorrect, it should be
"successmetrics-<release tag>.zip". This PR corrects this incorrect
naming.
