### PR TITLE
Allow pre commit failures

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -12,6 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - continue-on-error: true
       - name: Install Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -12,7 +12,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - continue-on-error: true
       - name: Install Python
         uses: actions/setup-python@v2
         with:
@@ -27,6 +26,7 @@ jobs:
       - name: Print git changes
         run: git status
       - uses: EndBug/add-and-commit@v7
+        continue-on-error: true
         with:
           default_author: github_actions
           message: "Pipeline pre-commit update"


### PR DESCRIPTION
In some cases the pre-commit action fails, this shouldn't block the pipeline so this PR allows
the currently failing step to pass. More analysis may be needed to see why the step fails.