### PR TITLE
Improve Actions test logging

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -51,7 +51,7 @@ jobs:
 
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          ./gradlew -Prelversion=$VERSION clean build test
+          ./gradlew -Prelversion=$VERSION clean build test --info
 
       - name: Generate JaCoCo Badge
         id: jacoco


### PR DESCRIPTION
While working on #31 it became clear that there wasn't enough information in the GitHub actions log to determins where the test step was failing.

This PR adds "--info" to the Gradle test command in GitHub actions to allow for more detailed output.
﻿
