### PR TITLE
Remove error on trailing slash on iq.url parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ iq.user
 iq.passwd
 ```
 
-:warning: iq.url should have no trailing `/` character.
-
 :warning: If you are using the get-metrics Docker image on the Nexus IQ machine then you cannot use `127.0.0.1` in the iq.url. You should instead use `host.docker.internal`.
 
 #### Time period for which data should be fetched

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQSuccessMetrics.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQSuccessMetrics.java
@@ -149,7 +149,9 @@ public class NexusIQSuccessMetrics {
     }
 
     private String getIqData(String endpoint) throws IOException, HttpException {
-
+        if ("/".equals(UtilService.lastChar(iqUrl))) {
+            iqUrl = UtilService.removeLastChar(iqUrl);
+        }
         String url = iqUrl + endpoint;
         log.info("Fetching data from: {}", url);
 

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/UtilService.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/UtilService.java
@@ -18,6 +18,10 @@ public class UtilService {
         return (s == null || s.length() == 0) ? null : (s.substring(0, s.length() - 1));
     }
 
+    public static String lastChar(String s) {
+        return s.substring(s.length() - 1);
+    }
+
     public static void writeCsvFile(String filename, List<String[]> data) throws IOException {
         try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(filename))) {
             writeCsvDataToBufferedWriter(data, writer);

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/util/NexusIqApiConnection.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/util/NexusIqApiConnection.java
@@ -2,6 +2,7 @@ package org.sonatype.cs.getmetrics.util;
 
 import org.apache.http.HttpException;
 import org.apache.tomcat.util.codec.binary.Base64;
+import org.sonatype.cs.getmetrics.service.UtilService;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -21,6 +22,9 @@ public class NexusIqApiConnection {
             String user, String password, String url, String api, String endPoint)
             throws IOException {
         String encodedAuthString = createEncodedAuthString(user, password);
+        if ("/".equals(UtilService.lastChar(url))) {
+            url = UtilService.removeLastChar(url);
+        }
         String urlString = url + api + endPoint;
         return createUrlConnection(urlString, encodedAuthString);
     }
@@ -54,6 +58,9 @@ public class NexusIqApiConnection {
             int page,
             int pageSize)
             throws IOException {
+        if ("/".equals(UtilService.lastChar(url))) {
+            url = UtilService.removeLastChar(url);
+        }
         String urlString =
                 url + api + endPoint + "?" + "page=" + page + "&pageSize=" + pageSize + "&asc=true";
         String encodedAuthString = createEncodedAuthString(user, password);
@@ -68,6 +75,9 @@ public class NexusIqApiConnection {
             String endpoint,
             String apiPayload)
             throws IOException, HttpException {
+        if ("/".equals(UtilService.lastChar(url))) {
+            url = UtilService.removeLastChar(url);
+        }
         HttpURLConnection urlConnection =
                 prepareHttpURLPostForCSV(user, password, url, api, endpoint);
         return executeHttpURLPostForCSV(apiPayload, urlConnection);

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/util/UtilServiceTest.java
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/util/UtilServiceTest.java
@@ -18,6 +18,10 @@ public class UtilServiceTest {
         Assertions.assertEquals(null, UtilService.removeLastChar(null));
     }
 
+    void testLastChar() {
+        Assertions.assertEquals("c", UtilService.lastChar("abc"));
+    }
+
     @Test
     void testWriteCsvDataToBufferedWriter() {
         StringWriter stringWriter = new StringWriter();


### PR DESCRIPTION
Before this PR the iq.url parameter in application.properties for get-metrics
must not end with a trailing backslash ("/"). After this PR a trailing backslash
will be removed from the iq.url if present, so the iq.url parameter may be set
either with or without the trailing backslash. As an example either of the 
following will be accepted after this PR:
  - http://127.0.0.1:8070
  - http://127.0.0.1:8070/﻿
