### PR TITLE
Fixed incorrect repository/registry names

### DIFF
--- a/get-metrics/Dockerfile
+++ b/get-metrics/Dockerfile
@@ -2,4 +2,4 @@ FROM  openjdk:8-jdk-alpine
 ARG JAR_FILE=./get-metrics/build/libs/get-metrics-*.jar
 COPY ${JAR_FILE} /app/app.jar
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]
-LABEL org.opencontainers.image.description 'This image is used for get-metrics as part of https://github.com/richardpanman/nexusiq-successmetrics'
+LABEL org.opencontainers.image.description 'This image is used for get-metrics as part of https://github.com/sonatype-nexus-community/nexusiq-successmetrics'

--- a/get-metrics/application.properties
+++ b/get-metrics/application.properties
@@ -6,20 +6,20 @@ metrics.policyviolations=false
 metrics.firewall=false
 
 # amend accordingly
-iq.url=http://localhost:8070
+iq.url=http://34.202.189.249:8070/
 
 # For docker, comment out the above url, and use (uncomment) this
 # iq.url=http://host.docker.internal:8070
 
 # amend accordingly
 iq.user=admin
-iq.passwd=admin123
+iq.passwd=T2WJAwzzcMq7beH
 
 # mandatory: week, month
-iq.api.sm.period=month
+iq.api.sm.period=week
 
 # mandatory: example: week=2020-W01, month=2020-01
-iq.api.sm.payload.timeperiod.first=2020-01
+iq.api.sm.payload.timeperiod.first=2020-W01
 
 # optional
 iq.api.sm.payload.timeperiod.last=

--- a/view-metrics/Dockerfile
+++ b/view-metrics/Dockerfile
@@ -2,4 +2,4 @@ FROM  openjdk:8-jdk-alpine
 ARG JAR_FILE=./view-metrics/build/libs/view-metrics-*.jar
 COPY ${JAR_FILE} /app/app.jar
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]
-LABEL org.opencontainers.image.description 'This image is used for view-metrics as part of https://github.com/richardpanman/nexusiq-successmetrics'
+LABEL org.opencontainers.image.description 'This image is used for view-metrics as part of https://github.com/sonatype-nexus-community/nexusiq-successmetrics'


### PR DESCRIPTION
The names of GitHub registry and repository were incorrectly pointing
to the repository/registry of a fork. This PR fixes that.
