### PR TITLE
Fixed incorrect repository/registry names (part 2)

### DIFF
--- a/.github/workflows/nexusiq-successmetrics.yml
+++ b/.github/workflows/nexusiq-successmetrics.yml
@@ -64,9 +64,9 @@ jobs:
           matrix:
             include:
               - dockerfile: ./get-metrics/Dockerfile
-                image: ghcr.io/richardpanman/nexusiq-successmetrics-get-metrics
+                image: ghcr.io/sonatype-nexus-community/nexusiq-successmetrics-get-metrics
               - dockerfile: ./view-metrics/Dockerfile
-                image: ghcr.io/richardpanman/nexusiq-successmetrics-view-metrics
+                image: ghcr.io/sonatype-nexus-community/nexusiq-successmetrics-view-metrics
         permissions:
           contents: read
           packages: write


### PR DESCRIPTION
The names of GitHub registry and repository were incorrectly pointing
to the repository/registry of a fork. This PR fixes that.
