### PR TITLE
Bumped apache-tomcat to 8.5.72

### DIFF
--- a/get-metrics/build.gradle
+++ b/get-metrics/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 	implementation 'org.apache.tomcat:tomcat-util:9.0.16'
 	implementation 'org.glassfish:javax.json:1.1'
 
-	implementation 'org.apache.tomcat:tomcat-coyote:8.0.44'
+	implementation 'org.apache.tomcat:tomcat-coyote:8.5.72'
 
 	implementation 'org.apache.commons:commons-csv:1.5'
 	implementation 'com.opencsv:opencsv:5.2'


### PR DESCRIPTION
Nexus IQ scan identified a critical security risk in tomcat-coyote:8.0.44
and recommended and upgdate to 8.5.72. This PR implements that change.﻿
