### PR TITLE
Bumped commons-codec to 1.10

### DIFF
--- a/get-metrics/build.gradle
+++ b/get-metrics/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	implementation 'org.apache.commons:commons-csv:1.5'
 	implementation 'com.opencsv:opencsv:5.2'
 	implementation 'org.apache.httpcomponents:httpclient:4.5.13'
-	implementation 'commons-codec:commons-codec:1.10'
+	implementation 'commons-codec:commons-codec:1.14'
 	implementation 'commons-io:commons-io:2.11.0'
 	implementation 'org.json:json:20210307'
 	implementation 'com.googlecode.json-simple:json-simple:1.1.1'

--- a/view-metrics/build.gradle
+++ b/view-metrics/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 	implementation 'org.xhtmlrenderer:flying-saucer-pdf-openpdf:9.1.20'
 	implementation 'org.apache.commons:commons-csv:1.5'
 	implementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    implementation 'commons-codec:commons-codec:1.10'
+    implementation 'commons-codec:commons-codec:1.14'
     implementation 'commons-io:commons-io:2.11.0'
 	implementation 'org.json:json:20210307'
 	implementation 'com.googlecode.json-simple:json-simple:1.1.1'


### PR DESCRIPTION
Nexus IQ scan identified security issues with commons-codec and recommended
bumping to 1.14. This PR implements that change.﻿
