### PR TITLE
Add a decimal place to risk ratio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,4 @@ iqmetrics
 
 !get-metrics/src/test/java/org/sonatype/cs/getmetrics/resources/**
 !view-metrics/src/test/resources
+view-metrics/src/test/resources/org/sonatype/cs/metrics/*.received.txt

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/model/DataExtractObject.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/model/DataExtractObject.java
@@ -4,8 +4,19 @@ import com.opencsv.bean.CsvBindByName;
 import com.opencsv.bean.CsvBindByPosition;
 import com.opencsv.bean.CsvDate;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
 import java.time.LocalDate;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
 public class DataExtractObject {
 
     @CsvDate(value = "yyyy-MM-dd")
@@ -27,7 +38,7 @@ public class DataExtractObject {
 
     @CsvBindByPosition(position = 4)
     @CsvBindByName(column = "RiskRatioOverall")
-    private int riskRatio;
+    private Double riskRatio;
 
     @CsvBindByPosition(position = 5)
     @CsvBindByName(column = "BacklogRateOverall")
@@ -67,7 +78,7 @@ public class DataExtractObject {
 
     @CsvBindByPosition(position = 14)
     @CsvBindByName(column = "SecurityRiskRatio")
-    private int securityRiskRatio;
+    private Double securityRiskRatio;
 
     @CsvBindByPosition(position = 15)
     @CsvBindByName(column = "SecurityBacklogRate")
@@ -95,7 +106,7 @@ public class DataExtractObject {
 
     @CsvBindByPosition(position = 21)
     @CsvBindByName(column = "LicenseRiskRatio")
-    private int licenseRiskRatio;
+    private Double licenseRiskRatio;
 
     @CsvBindByPosition(position = 22)
     @CsvBindByName(column = "LicenseBacklogRate")
@@ -123,7 +134,7 @@ public class DataExtractObject {
 
     @CsvBindByPosition(position = 28)
     @CsvBindByName(column = "SecurityCriticalRiskRatio")
-    private int securityCriticalRiskRatio;
+    private Double securityCriticalRiskRatio;
 
     @CsvBindByPosition(position = 29)
     @CsvBindByName(column = "SecurityCriticalBacklogRate")
@@ -151,7 +162,7 @@ public class DataExtractObject {
 
     @CsvBindByPosition(position = 35)
     @CsvBindByName(column = "LicenseCriticalRiskRatio")
-    private int licenseCriticalRiskRatio;
+    private Double licenseCriticalRiskRatio;
 
     @CsvBindByPosition(position = 36)
     @CsvBindByName(column = "LicenseCriticalBacklogRate")
@@ -179,7 +190,7 @@ public class DataExtractObject {
 
     @CsvBindByPosition(position = 42)
     @CsvBindByName(column = "SecuritySevereRiskRatio")
-    private int securitySevereRiskRatio;
+    private Double securitySevereRiskRatio;
 
     @CsvBindByPosition(position = 43)
     @CsvBindByName(column = "SecuritySevereBacklogRate")
@@ -207,7 +218,7 @@ public class DataExtractObject {
 
     @CsvBindByPosition(position = 49)
     @CsvBindByName(column = "LicenseSevereRiskRatio")
-    private int licenseSevereRiskRatio;
+    private Double licenseSevereRiskRatio;
 
     @CsvBindByPosition(position = 50)
     @CsvBindByName(column = "LicenseSevereBacklogRate")
@@ -235,7 +246,7 @@ public class DataExtractObject {
 
     @CsvBindByPosition(position = 56)
     @CsvBindByName(column = "SecurityModerateRiskRatio")
-    private int securityModerateRiskRatio;
+    private Double securityModerateRiskRatio;
 
     @CsvBindByPosition(position = 57)
     @CsvBindByName(column = "SecurityModerateBacklogRate")
@@ -263,7 +274,7 @@ public class DataExtractObject {
 
     @CsvBindByPosition(position = 63)
     @CsvBindByName(column = "LicenseModerateRiskRatio")
-    private int licenseModerateRiskRatio;
+    private Double licenseModerateRiskRatio;
 
     @CsvBindByPosition(position = 64)
     @CsvBindByName(column = "LicenseModerateBacklogRate")
@@ -288,564 +299,4 @@ public class DataExtractObject {
     @CsvBindByPosition(position = 69)
     @CsvBindByName(column = "LicenseModerateWaived")
     private int licenseModerateWaived;
-
-    public LocalDate getDate() {
-        return date;
-    }
-
-    public void setDate(LocalDate date) {
-        this.date = date;
-    }
-
-    public int getTotalApplicationsOnboard() {
-        return totalApplicationsOnboard;
-    }
-
-    public void setTotalApplicationsOnboard(int totalApplicationsOnboard) {
-        this.totalApplicationsOnboard = totalApplicationsOnboard;
-    }
-
-    public int getTotalScans() {
-        return totalScans;
-    }
-
-    public void setTotalScans(int totalScans) {
-        this.totalScans = totalScans;
-    }
-
-    public int getTotalUniqueApplicationsScaned() {
-        return totalUniqueApplicationsScaned;
-    }
-
-    public void setTotalUniqueApplicationsScaned(int totalUniqueApplicationsScaned) {
-        this.totalUniqueApplicationsScaned = totalUniqueApplicationsScaned;
-    }
-
-    public int getRiskRatio() {
-        return riskRatio;
-    }
-
-    public void setRiskRatio(int riskRatio) {
-        this.riskRatio = riskRatio;
-    }
-
-    public int getBacklogRate() {
-        return backlogRate;
-    }
-
-    public void setBacklogRate(int backlogRate) {
-        this.backlogRate = backlogRate;
-    }
-
-    public float getDiscoveryRate() {
-        return discoveryRate;
-    }
-
-    public void setDiscoveryRate(float discoveryRate) {
-        this.discoveryRate = discoveryRate;
-    }
-
-    public int getAllDiscovered() {
-        return allDiscovered;
-    }
-
-    public void setAllDiscovered(int allDiscovered) {
-        this.allDiscovered = allDiscovered;
-    }
-
-    public int getAllOpen() {
-        return allOpen;
-    }
-
-    public void setAllOpen(int allOpen) {
-        this.allOpen = allOpen;
-    }
-
-    public int getAllFixed() {
-        return allFixed;
-    }
-
-    public void setAllFixed(int allFixed) {
-        this.allFixed = allFixed;
-    }
-
-    public int getAllWaived() {
-        return allWaived;
-    }
-
-    public void setAllWaived(int allWaived) {
-        this.allWaived = allWaived;
-    }
-
-    public int getMttrCritical() {
-        return mttrCritical;
-    }
-
-    public void setMttrCritical(int mttrCritical) {
-        this.mttrCritical = mttrCritical;
-    }
-
-    public int getMttrSevere() {
-        return mttrSevere;
-    }
-
-    public void setMttrSevere(int mttrSevere) {
-        this.mttrSevere = mttrSevere;
-    }
-
-    public int getMttrModerate() {
-        return mttrModerate;
-    }
-
-    public void setMttrModerate(int mttrModerate) {
-        this.mttrModerate = mttrModerate;
-    }
-
-    public int getSecurityRiskRatio() {
-        return securityRiskRatio;
-    }
-
-    public void setSecurityRiskRatio(int securityRiskRatio) {
-        this.securityRiskRatio = securityRiskRatio;
-    }
-
-    public int getSecurityBacklogRate() {
-        return securityBacklogRate;
-    }
-
-    public void setSecurityBacklogRate(int securityBacklogRate) {
-        this.securityBacklogRate = securityBacklogRate;
-    }
-
-    public float getSecurityDiscoveryRate() {
-        return securityDiscoveryRate;
-    }
-
-    public void setSecurityDiscoveryRate(float securityDiscoveryRate) {
-        this.securityDiscoveryRate = securityDiscoveryRate;
-    }
-
-    public int getSecurityDiscovered() {
-        return securityDiscovered;
-    }
-
-    public void setSecurityDiscovered(int securityDiscovered) {
-        this.securityDiscovered = securityDiscovered;
-    }
-
-    public int getSecurityOpen() {
-        return securityOpen;
-    }
-
-    public void setSecurityOpen(int securityOpen) {
-        this.securityOpen = securityOpen;
-    }
-
-    public int getSecurityFixed() {
-        return securityFixed;
-    }
-
-    public void setSecurityFixed(int securityFixed) {
-        this.securityFixed = securityFixed;
-    }
-
-    public int getSecurityWaived() {
-        return securityWaived;
-    }
-
-    public void setSecurityWaived(int securityWaived) {
-        this.securityWaived = securityWaived;
-    }
-
-    public int getLicenseRiskRatio() {
-        return licenseRiskRatio;
-    }
-
-    public void setLicenseRiskRatio(int licenseRiskRatio) {
-        this.licenseRiskRatio = licenseRiskRatio;
-    }
-
-    public int getLicenseBacklogRate() {
-        return licenseBacklogRate;
-    }
-
-    public void setLicenseBacklogRate(int licenseBacklogRate) {
-        this.licenseBacklogRate = licenseBacklogRate;
-    }
-
-    public float getLicenseDiscoveryRate() {
-        return licenseDiscoveryRate;
-    }
-
-    public void setLicenseDiscoveryRate(float licenseDiscoveryRate) {
-        this.licenseDiscoveryRate = licenseDiscoveryRate;
-    }
-
-    public int getLicenseDiscovered() {
-        return licenseDiscovered;
-    }
-
-    public void setLicenseDiscovered(int licenseDiscovered) {
-        this.licenseDiscovered = licenseDiscovered;
-    }
-
-    public int getLicenseOpen() {
-        return licenseOpen;
-    }
-
-    public void setLicenseOpen(int licenseOpen) {
-        this.licenseOpen = licenseOpen;
-    }
-
-    public int getLicenseFixed() {
-        return licenseFixed;
-    }
-
-    public void setLicenseFixed(int licenseFixed) {
-        this.licenseFixed = licenseFixed;
-    }
-
-    public int getLicenseWaived() {
-        return licenseWaived;
-    }
-
-    public void setLicenseWaived(int licenseWaived) {
-        this.licenseWaived = licenseWaived;
-    }
-
-    public int getSecurityCriticalRiskRatio() {
-        return securityCriticalRiskRatio;
-    }
-
-    public void setSecurityCriticalRiskRatio(int securityCriticalRiskRatio) {
-        this.securityCriticalRiskRatio = securityCriticalRiskRatio;
-    }
-
-    public int getSecurityCriticalBacklogRate() {
-        return securityCriticalBacklogRate;
-    }
-
-    public void setSecurityCriticalBacklogRate(int securityCriticalBacklogRate) {
-        this.securityCriticalBacklogRate = securityCriticalBacklogRate;
-    }
-
-    public float getSecurityCriticalDiscoveryRate() {
-        return securityCriticalDiscoveryRate;
-    }
-
-    public void setSecurityCriticalDiscoveryRate(float securityCriticalDiscoveryRate) {
-        this.securityCriticalDiscoveryRate = securityCriticalDiscoveryRate;
-    }
-
-    public int getSecurityCriticalDiscovered() {
-        return securityCriticalDiscovered;
-    }
-
-    public void setSecurityCriticalDiscovered(int securityCriticalDiscovered) {
-        this.securityCriticalDiscovered = securityCriticalDiscovered;
-    }
-
-    public int getSecurityCriticalOpen() {
-        return securityCriticalOpen;
-    }
-
-    public void setSecurityCriticalOpen(int securityCriticalOpen) {
-        this.securityCriticalOpen = securityCriticalOpen;
-    }
-
-    public int getSecurityCriticalFixed() {
-        return securityCriticalFixed;
-    }
-
-    public void setSecurityCriticalFixed(int securityCriticalFixed) {
-        this.securityCriticalFixed = securityCriticalFixed;
-    }
-
-    public int getSecurityCriticalWaived() {
-        return securityCriticalWaived;
-    }
-
-    public void setSecurityCriticalWaived(int securityCriticalWaived) {
-        this.securityCriticalWaived = securityCriticalWaived;
-    }
-
-    public int getLicenseCriticalRiskRatio() {
-        return licenseCriticalRiskRatio;
-    }
-
-    public void setLicenseCriticalRiskRatio(int licenseCriticalRiskRatio) {
-        this.licenseCriticalRiskRatio = licenseCriticalRiskRatio;
-    }
-
-    public int getLicenseCriticalBacklogRate() {
-        return licenseCriticalBacklogRate;
-    }
-
-    public void setLicenseCriticalBacklogRate(int licenseCriticalBacklogRate) {
-        this.licenseCriticalBacklogRate = licenseCriticalBacklogRate;
-    }
-
-    public float getLicenseCriticalDiscoveryRate() {
-        return licenseCriticalDiscoveryRate;
-    }
-
-    public void setLicenseCriticalDiscoveryRate(float licenseCriticalDiscoveryRate) {
-        this.licenseCriticalDiscoveryRate = licenseCriticalDiscoveryRate;
-    }
-
-    public int getLicenseCriticalDiscovered() {
-        return licenseCriticalDiscovered;
-    }
-
-    public void setLicenseCriticalDiscovered(int licenseCriticalDiscovered) {
-        this.licenseCriticalDiscovered = licenseCriticalDiscovered;
-    }
-
-    public int getLicenseCriticalOpen() {
-        return licenseCriticalOpen;
-    }
-
-    public void setLicenseCriticalOpen(int licenseCriticalOpen) {
-        this.licenseCriticalOpen = licenseCriticalOpen;
-    }
-
-    public int getLicenseCriticalFixed() {
-        return licenseCriticalFixed;
-    }
-
-    public void setLicenseCriticalFixed(int licenseCriticalFixed) {
-        this.licenseCriticalFixed = licenseCriticalFixed;
-    }
-
-    public int getLicenseCriticalWaived() {
-        return licenseCriticalWaived;
-    }
-
-    public void setLicenseCriticalWaived(int licenseCriticalWaived) {
-        this.licenseCriticalWaived = licenseCriticalWaived;
-    }
-
-    public int getSecuritySevereRiskRatio() {
-        return securitySevereRiskRatio;
-    }
-
-    public void setSecuritySevereRiskRatio(int securitySevereRiskRatio) {
-        this.securitySevereRiskRatio = securitySevereRiskRatio;
-    }
-
-    public int getSecuritySevereBacklogRate() {
-        return securitySevereBacklogRate;
-    }
-
-    public void setSecuritySevereBacklogRate(int securitySevereBacklogRate) {
-        this.securitySevereBacklogRate = securitySevereBacklogRate;
-    }
-
-    public float getSecuritySevereDiscoveryRate() {
-        return securitySevereDiscoveryRate;
-    }
-
-    public void setSecuritySevereDiscoveryRate(float securitySevereDiscoveryRate) {
-        this.securitySevereDiscoveryRate = securitySevereDiscoveryRate;
-    }
-
-    public int getSecuritySevereDiscovered() {
-        return securitySevereDiscovered;
-    }
-
-    public void setSecuritySevereDiscovered(int securitySevereDiscovered) {
-        this.securitySevereDiscovered = securitySevereDiscovered;
-    }
-
-    public int getSecuritySevereOpen() {
-        return securitySevereOpen;
-    }
-
-    public void setSecuritySevereOpen(int securitySevereOpen) {
-        this.securitySevereOpen = securitySevereOpen;
-    }
-
-    public int getSecuritySevereFixed() {
-        return securitySevereFixed;
-    }
-
-    public void setSecuritySevereFixed(int securitySevereFixed) {
-        this.securitySevereFixed = securitySevereFixed;
-    }
-
-    public int getSecuritySevereWaived() {
-        return securitySevereWaived;
-    }
-
-    public void setSecuritySevereWaived(int securitySevereWaived) {
-        this.securitySevereWaived = securitySevereWaived;
-    }
-
-    public int getLicenseSevereRiskRatio() {
-        return licenseSevereRiskRatio;
-    }
-
-    public void setLicenseSevereRiskRatio(int licenseSevereRiskRatio) {
-        this.licenseSevereRiskRatio = licenseSevereRiskRatio;
-    }
-
-    public int getLicenseSevereBacklogRate() {
-        return licenseSevereBacklogRate;
-    }
-
-    public void setLicenseSevereBacklogRate(int licenseSevereBacklogRate) {
-        this.licenseSevereBacklogRate = licenseSevereBacklogRate;
-    }
-
-    public float getLicenseSevereDiscoveryRate() {
-        return licenseSevereDiscoveryRate;
-    }
-
-    public void setLicenseSevereDiscoveryRate(float licenseSevereDiscoveryRate) {
-        this.licenseSevereDiscoveryRate = licenseSevereDiscoveryRate;
-    }
-
-    public int getLicenseSevereDiscovered() {
-        return licenseSevereDiscovered;
-    }
-
-    public void setLicenseSevereDiscovered(int licenseSevereDiscovered) {
-        this.licenseSevereDiscovered = licenseSevereDiscovered;
-    }
-
-    public int getLicenseSevereOpen() {
-        return licenseSevereOpen;
-    }
-
-    public void setLicenseSevereOpen(int licenseSevereOpen) {
-        this.licenseSevereOpen = licenseSevereOpen;
-    }
-
-    public int getLicenseSevereFixed() {
-        return licenseSevereFixed;
-    }
-
-    public void setLicenseSevereFixed(int licenseSevereFixed) {
-        this.licenseSevereFixed = licenseSevereFixed;
-    }
-
-    public int getLicenseSevereWaived() {
-        return licenseSevereWaived;
-    }
-
-    public void setLicenseSevereWaived(int licenseSevereWaived) {
-        this.licenseSevereWaived = licenseSevereWaived;
-    }
-
-    public int getSecurityModerateRiskRatio() {
-        return securityModerateRiskRatio;
-    }
-
-    public void setSecurityModerateRiskRatio(int securityModerateRiskRatio) {
-        this.securityModerateRiskRatio = securityModerateRiskRatio;
-    }
-
-    public int getSecurityModerateBacklogRate() {
-        return securityModerateBacklogRate;
-    }
-
-    public void setSecurityModerateBacklogRate(int securityModerateBacklogRate) {
-        this.securityModerateBacklogRate = securityModerateBacklogRate;
-    }
-
-    public float getSecurityModerateDiscoveryRate() {
-        return securityModerateDiscoveryRate;
-    }
-
-    public void setSecurityModerateDiscoveryRate(float securityModerateDiscoveryRate) {
-        this.securityModerateDiscoveryRate = securityModerateDiscoveryRate;
-    }
-
-    public int getSecurityModerateDiscovered() {
-        return securityModerateDiscovered;
-    }
-
-    public void setSecurityModerateDiscovered(int securityModerateDiscovered) {
-        this.securityModerateDiscovered = securityModerateDiscovered;
-    }
-
-    public int getSecurityModerateOpen() {
-        return securityModerateOpen;
-    }
-
-    public void setSecurityModerateOpen(int securityModerateOpen) {
-        this.securityModerateOpen = securityModerateOpen;
-    }
-
-    public int getSecurityModerateFixed() {
-        return securityModerateFixed;
-    }
-
-    public void setSecurityModerateFixed(int securityModerateFixed) {
-        this.securityModerateFixed = securityModerateFixed;
-    }
-
-    public int getSecurityModerateWaived() {
-        return securityModerateWaived;
-    }
-
-    public void setSecurityModerateWaived(int securityModerateWaived) {
-        this.securityModerateWaived = securityModerateWaived;
-    }
-
-    public int getLicenseModerateRiskRatio() {
-        return licenseModerateRiskRatio;
-    }
-
-    public void setLicenseModerateRiskRatio(int licenseModerateRiskRatio) {
-        this.licenseModerateRiskRatio = licenseModerateRiskRatio;
-    }
-
-    public int getLicenseModerateBacklogRate() {
-        return licenseModerateBacklogRate;
-    }
-
-    public void setLicenseModerateBacklogRate(int licenseModerateBacklogRate) {
-        this.licenseModerateBacklogRate = licenseModerateBacklogRate;
-    }
-
-    public float getLicenseModerateDiscoveryRate() {
-        return licenseModerateDiscoveryRate;
-    }
-
-    public void setLicenseModerateDiscoveryRate(float licenseModerateDiscoveryRate) {
-        this.licenseModerateDiscoveryRate = licenseModerateDiscoveryRate;
-    }
-
-    public int getLicenseModerateDiscovered() {
-        return licenseModerateDiscovered;
-    }
-
-    public void setLicenseModerateDiscovered(int licenseModerateDiscovered) {
-        this.licenseModerateDiscovered = licenseModerateDiscovered;
-    }
-
-    public int getLicenseModerateOpen() {
-        return licenseModerateOpen;
-    }
-
-    public void setLicenseModerateOpen(int licenseModerateOpen) {
-        this.licenseModerateOpen = licenseModerateOpen;
-    }
-
-    public int getLicenseModerateFixed() {
-        return licenseModerateFixed;
-    }
-
-    public void setLicenseModerateFixed(int licenseModerateFixed) {
-        this.licenseModerateFixed = licenseModerateFixed;
-    }
-
-    public int getLicenseModerateWaived() {
-        return licenseModerateWaived;
-    }
-
-    public void setLicenseModerateWaived(int licenseModerateWaived) {
-        this.licenseModerateWaived = licenseModerateWaived;
-    }
 }

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/model/PeriodData.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/model/PeriodData.java
@@ -1,0 +1,17 @@
+package org.sonatype.cs.metrics.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.sql.Date;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@ToString
+public class PeriodData {
+    Date timePeriodStart;
+    Double riskRatio;
+}

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/model/RiskRatio.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/model/RiskRatio.java
@@ -1,0 +1,15 @@
+package org.sonatype.cs.metrics.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+public class RiskRatio {
+    private String label;
+    private Double riskRatioValue;
+}

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/service/ApplicationsDataService.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/service/ApplicationsDataService.java
@@ -2,11 +2,13 @@ package org.sonatype.cs.metrics.service;
 
 import org.sonatype.cs.metrics.model.DbRow;
 import org.sonatype.cs.metrics.model.Mttr;
+import org.sonatype.cs.metrics.model.RiskRatio;
 import org.sonatype.cs.metrics.util.HelperService;
 import org.sonatype.cs.metrics.util.SqlStatements;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -114,10 +116,24 @@ public class ApplicationsDataService {
                     dbService.runSql(tableName, SqlStatements.MOSTSCANNEDAPPLICATIONS));
         }
 
-        List<DbRow> riskRatio = dbService.runSql(tableName, SqlStatements.RISKRATIO);
-        model.put("riskRatioChart", riskRatio);
-        model.put("riskRatioAtEndPeriod", riskRatio.get(riskRatio.size() - 1).getPointA());
-        model.put("riskRatioAtStartPeriod", riskRatio.get(0).getPointA());
+        List<RiskRatio> riskRatios = new ArrayList<>();
+        dbService
+                .runSql(tableName, SqlStatements.RISKRATIOCOMPONENTS)
+                .forEach(
+                        timePeriod -> {
+                            Double riskRatioValue =
+                                    (Double.valueOf(timePeriod.getPointA())
+                                                    + Double.valueOf(timePeriod.getPointB()))
+                                            / Double.valueOf(timePeriod.getPointC());
+
+                            riskRatios.add(new RiskRatio(timePeriod.getLabel(), riskRatioValue));
+                        });
+        model.put("riskRatioChart", riskRatios);
+        model.put(
+                "riskRatioAtEndPeriod", riskRatios.get(riskRatios.size() - 1).getRiskRatioValue());
+        model.put(
+                "riskRatioAtStartPeriod",
+                riskRatios.get(riskRatios.size() - 1).getRiskRatioValue());
 
         return model;
     }

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/util/HelperService.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/util/HelperService.java
@@ -71,4 +71,22 @@ public class HelperService {
                 LocalDateTime.parse(str, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
         return localDate.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
     }
+
+    public static Double roundDouble(Double value, int places) {
+        if (places < 0) throw new IllegalArgumentException();
+
+        long factor = (long) Math.pow(10, places);
+        value = value * factor;
+        long tmp = Math.round(value);
+        return (double) tmp / factor;
+    }
+
+    public static Float roundFloat(Float value, int places) {
+        if (places < 0) throw new IllegalArgumentException();
+
+        long factor = (long) Math.pow(10, places);
+        value = value * factor;
+        long tmp = Math.round(value);
+        return (float) tmp / factor;
+    }
 }

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/util/SqlStatements.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/util/SqlStatements.java
@@ -327,6 +327,13 @@ public class SqlStatements {
                 + " sum(OPEN_COUNT_AT_TIME_PERIOD_END_LICENSE_CRITICAL))/count(time_period_start)"
                 + " as pointA from <?> group by time_period_start order by 1";
 
+    public static final String RISKRATIOCOMPONENTS =
+            "select time_period_start as label,"
+                    + " sum(OPEN_COUNT_AT_TIME_PERIOD_END_SECURITY_CRITICAL) as pointA,"
+                    + " sum(OPEN_COUNT_AT_TIME_PERIOD_END_LICENSE_CRITICAL) as pointB,"
+                    + " count(time_period_start) as pointC "
+                    + " from <?> group by time_period_start order by 1";
+
     public static final String RISKRATIOANALYSIS =
             "select application_name as label,"
                 + " (sum(OPEN_COUNT_AT_TIME_PERIOD_END_SECURITY_CRITICAL) +"

--- a/view-metrics/src/main/resources/application.properties
+++ b/view-metrics/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 # web, data
 # web = run the interactive web application
 # data = creates summary report and data files, then exits
-spring.profiles.active=web
+spring.profiles.active=data
 
 # directory in which zip file is unzipped ie. the working directory
 # to load the csv files from another location, set it here

--- a/view-metrics/src/main/resources/templates/fragmentApplications.html
+++ b/view-metrics/src/main/resources/templates/fragmentApplications.html
@@ -125,7 +125,7 @@
 
 	     	points.forEach(entry => {
 	            var label = entry.label;
-	            var point = entry.pointA;
+	            var point = entry.riskRatioValue.toFixed(1);
 	            labels.push(label);
 	            pdata.push(point);
 	        });

--- a/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.analysis.html.approved.txt
+++ b/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.analysis.html.approved.txt
@@ -222,10 +222,10 @@
             <tr style="font-weight:bold">
                 <td>Scanning Rate (total scans per period)</td>
                 <td>237.00</td>
-                <td>148.00</td>
-                <td>-89.00</td>
-                <td>-37.55</td>
-                <td>0.62</td>
+                <td>148.33</td>
+                <td>-88.67</td>
+                <td>-37.41</td>
+                <td>0.63</td>
             </tr>
 
             <tr style="font-weight:bold">
@@ -233,25 +233,25 @@
                 <td>5.27</td>
                 <td>1.16</td>
                 <td>-4.11</td>
-                <td>-78.05</td>
+                <td>-78.00</td>
                 <td>0.22</td>
             </tr>
 
             <tr style="font-weight:bold">
                 <td>Discovery Rate Criticals (# of discovered Critical violations/period &amp; app)</td>
-                <td>11.51</td>
+                <td>11.52</td>
                 <td>3.93</td>
-                <td>-7.58</td>
-                <td>-65.86</td>
+                <td>-7.59</td>
+                <td>-65.88</td>
                 <td>0.34</td>
             </tr>
 
             <tr style="font-weight:bold">
                 <td>Fixing Rate Criticals (# of fixed Critical violations/period &amp; app)</td>
-                <td>2.91</td>
-                <td>0.57</td>
-                <td>-2.34</td>
-                <td>-80.41</td>
+                <td>2.93</td>
+                <td>0.58</td>
+                <td>-2.35</td>
+                <td>-80.33</td>
                 <td>0.20</td>
             </tr>
 
@@ -266,11 +266,11 @@
 
             <tr style="font-weight:bold">
                 <td>Risk Ratio (# of Critical violations / # of apps)</td>
-                <td>24.0</td>
-                <td>20.0</td>
-                <td>-4</td>
-                <td>-16.67</td>
-                <td>0.83</td>
+                <td>25.711111111111112</td>
+                <td>20.90625</td>
+                <td>-4.804861111111112137450618320144712924957275390625</td>
+                <td>-18.69</td>
+                <td>0.81</td>
             </tr>
 
             <tr style="font-weight:bold">

--- a/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.applications.html.approved.txt
+++ b/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.applications.html.approved.txt
@@ -274,13 +274,13 @@
 
         <div id="riskRatioChart"></div>
         <script>
-            var points = [{"label":"2021-01-01","pointA":24,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-02-01","pointA":21,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-03-01","pointA":25,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-04-01","pointA":24,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-05-01","pointA":20,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-06-01","pointA":20,"pointB":0,"pointC":0,"pointD":0}];
+            var points = [{"label":"2021-01-01","riskRatioValue":24.333333333333332},{"label":"2021-02-01","riskRatioValue":21.941176470588236},{"label":"2021-03-01","riskRatioValue":25.711111111111112},{"label":"2021-04-01","riskRatioValue":24.315068493150687},{"label":"2021-05-01","riskRatioValue":20.57943925233645},{"label":"2021-06-01","riskRatioValue":20.90625}];
 	     	var pdata = [];
 	     	var labels = [];
 
 	     	points.forEach(entry => {
 	            var label = entry.label;
-	            var point = entry.pointA;
+	            var point = entry.riskRatioValue.toFixed(1);
 	            labels.push(label);
 	            pdata.push(point);
 	        });

--- a/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.appsummary.html?appname=webgoatj.approved.txt
+++ b/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.appsummary.html?appname=webgoatj.approved.txt
@@ -345,13 +345,13 @@
 
         <div id="riskRatioChart"></div>
         <script>
-            var points = [{"label":"2021-01-01","pointA":52,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-02-01","pointA":52,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-03-01","pointA":53,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-04-01","pointA":53,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-05-01","pointA":53,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-06-01","pointA":53,"pointB":0,"pointC":0,"pointD":0}];
+            var points = [{"label":"2021-01-01","riskRatioValue":52.0},{"label":"2021-02-01","riskRatioValue":52.0},{"label":"2021-03-01","riskRatioValue":53.0},{"label":"2021-04-01","riskRatioValue":53.0},{"label":"2021-05-01","riskRatioValue":53.0},{"label":"2021-06-01","riskRatioValue":53.0}];
 	     	var pdata = [];
 	     	var labels = [];
 
 	     	points.forEach(entry => {
 	            var label = entry.label;
-	            var point = entry.pointA;
+	            var point = entry.riskRatioValue.toFixed(1);
 	            labels.push(label);
 	            pdata.push(point);
 	        });

--- a/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.summary.html.approved.txt
+++ b/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.summary.html.approved.txt
@@ -440,13 +440,13 @@
 
         <div id="riskRatioChart"></div>
         <script>
-            var points = [{"label":"2021-01-01","pointA":24,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-02-01","pointA":21,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-03-01","pointA":25,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-04-01","pointA":24,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-05-01","pointA":20,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-06-01","pointA":20,"pointB":0,"pointC":0,"pointD":0}];
+            var points = [{"label":"2021-01-01","riskRatioValue":24.333333333333332},{"label":"2021-02-01","riskRatioValue":21.941176470588236},{"label":"2021-03-01","riskRatioValue":25.711111111111112},{"label":"2021-04-01","riskRatioValue":24.315068493150687},{"label":"2021-05-01","riskRatioValue":20.57943925233645},{"label":"2021-06-01","riskRatioValue":20.90625}];
 	     	var pdata = [];
 	     	var labels = [];
 
 	     	points.forEach(entry => {
 	            var label = entry.label;
-	            var point = entry.pointA;
+	            var point = entry.riskRatioValue.toFixed(1);
 	            labels.push(label);
 	            pdata.push(point);
 	        });

--- a/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationUsingApplicationTest.checkPageContents.applications.html.approved.txt
+++ b/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationUsingApplicationTest.checkPageContents.applications.html.approved.txt
@@ -274,13 +274,13 @@
 
         <div id="riskRatioChart"></div>
         <script>
-            var points = [{"label":"2021-01-01","pointA":24,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-02-01","pointA":21,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-03-01","pointA":25,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-04-01","pointA":24,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-05-01","pointA":20,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-06-01","pointA":20,"pointB":0,"pointC":0,"pointD":0}];
+            var points = [{"label":"2021-01-01","riskRatioValue":24.333333333333332},{"label":"2021-02-01","riskRatioValue":21.941176470588236},{"label":"2021-03-01","riskRatioValue":25.711111111111112},{"label":"2021-04-01","riskRatioValue":24.315068493150687},{"label":"2021-05-01","riskRatioValue":20.57943925233645},{"label":"2021-06-01","riskRatioValue":20.90625}];
 	     	var pdata = [];
 	     	var labels = [];
 
 	     	points.forEach(entry => {
 	            var label = entry.label;
-	            var point = entry.pointA;
+	            var point = entry.riskRatioValue.toFixed(1);
 	            labels.push(label);
 	            pdata.push(point);
 	        });

--- a/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationUsingOrganisationTest.checkPageContents.applications.html.approved.txt
+++ b/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationUsingOrganisationTest.checkPageContents.applications.html.approved.txt
@@ -274,13 +274,13 @@
 
         <div id="riskRatioChart"></div>
         <script>
-            var points = [{"label":"2021-01-01","pointA":24,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-02-01","pointA":21,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-03-01","pointA":25,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-04-01","pointA":24,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-05-01","pointA":20,"pointB":0,"pointC":0,"pointD":0},{"label":"2021-06-01","pointA":20,"pointB":0,"pointC":0,"pointD":0}];
+            var points = [{"label":"2021-01-01","riskRatioValue":24.333333333333332},{"label":"2021-02-01","riskRatioValue":21.941176470588236},{"label":"2021-03-01","riskRatioValue":25.711111111111112},{"label":"2021-04-01","riskRatioValue":24.315068493150687},{"label":"2021-05-01","riskRatioValue":20.57943925233645},{"label":"2021-06-01","riskRatioValue":20.90625}];
 	     	var pdata = [];
 	     	var labels = [];
 
 	     	points.forEach(entry => {
 	            var label = entry.label;
-	            var point = entry.pointA;
+	            var point = entry.riskRatioValue.toFixed(1);
 	            labels.push(label);
 	            pdata.push(point);
 	        });

--- a/view-metrics/src/test/resources/org/sonatype/cs/metrics/TestSuccessMetricsIsightsApplicationTo202106.checkCSVFileIsGenerated.approved.txt
+++ b/view-metrics/src/test/resources/org/sonatype/cs/metrics/TestSuccessMetricsIsightsApplicationTo202106.checkCSVFileIsGenerated.approved.txt
@@ -5,8 +5,8 @@ Total Scans,711.0,298.0,-413.00,-58.09,0.42
 Scanning Coverage %(apps scanned at least once/period),71.11,37.38,-33.73,-47.43,0.53
 Scanning Rate (total scans per period),237.00,149.00,-88.00,-37.13,0.63
 Average Scans per App (scanning rate/apps),5.27,1.39,-3.87,-73.56,0.26
-Discovery Rate Criticals (# of discovered Critical violations/period & app),11.51,5.89,-5.62,-48.85,0.51
-Fixing Rate Criticals (# of fixed Critical violations/period & app),2.91,0.98,-1.93,-66.29,0.34
+Discovery Rate Criticals (# of discovered Critical violations/period & app),11.52,5.89,-5.63,-48.88,0.51
+Fixing Rate Criticals (# of fixed Critical violations/period & app),2.93,0.99,-1.94,-66.30,0.34
 Backlog Reduction Rate Criticals %(# of fixed / # of discovered),59.39,16.75,-42.65,-71.80,0.28
-Risk Ratio (# of Critical violations / # of apps),24.0,20.0,-4.00,-16.67,0.83
+Risk Ratio (# of Critical violations / # of apps),25.7,20.6,-5.1,-19.96,0.80
 MTTR Criticals (average # of days to fix Critical violations),22,28,6.00,27.27,1.27

--- a/view-metrics/src/test/resources/org/sonatype/cs/metrics/TestSuccessMetricsIsightsApplicationTo202107.checkCSVFileIsGenerated.approved.txt
+++ b/view-metrics/src/test/resources/org/sonatype/cs/metrics/TestSuccessMetricsIsightsApplicationTo202107.checkCSVFileIsGenerated.approved.txt
@@ -3,10 +3,10 @@ Total Onboarded Apps (# of apps),45,128,83.00,184.44,2.84
 Onboarding Rate (apps/period),8.00,27.67,19.67,0.00,3.46
 Total Scans,711.0,445.0,-266.00,-37.41,0.63
 Scanning Coverage %(apps scanned at least once/period),71.11,27.34,-43.77,-61.55,0.38
-Scanning Rate (total scans per period),237.00,148.00,-89.00,-37.55,0.62
-Average Scans per App (scanning rate/apps),5.27,1.16,-4.11,-78.05,0.22
-Discovery Rate Criticals (# of discovered Critical violations/period & app),11.51,3.93,-7.58,-65.86,0.34
-Fixing Rate Criticals (# of fixed Critical violations/period & app),2.91,0.57,-2.34,-80.41,0.20
+Scanning Rate (total scans per period),237.00,148.33,-88.67,-37.41,0.63
+Average Scans per App (scanning rate/apps),5.27,1.16,-4.11,-78.00,0.22
+Discovery Rate Criticals (# of discovered Critical violations/period & app),11.52,3.93,-7.59,-65.88,0.34
+Fixing Rate Criticals (# of fixed Critical violations/period & app),2.93,0.58,-2.35,-80.33,0.20
 Backlog Reduction Rate Criticals %(# of fixed / # of discovered),59.39,12.67,-46.72,-78.66,0.21
-Risk Ratio (# of Critical violations / # of apps),24.0,20.0,-4.00,-16.67,0.83
+Risk Ratio (# of Critical violations / # of apps),25.7,20.9,-4.8,-18.69,0.81
 MTTR Criticals (average # of days to fix Critical violations),22,36,14.00,63.64,1.64


### PR DESCRIPTION
Before this PR risk ratio calculations are performed using integer arithmetic which
leads to loss of detail (for example 0.99 would be rounded to 0). After this PR
risk ratio is calculated properly and represented in reports to one decimal place.
