### PR TITLE
Restore default view-metrics mode

### DIFF
--- a/view-metrics/src/main/resources/application.properties
+++ b/view-metrics/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 # web, data
 # web = run the interactive web application
 # data = creates summary report and data files, then exits
-spring.profiles.active=data
+spring.profiles.active=web
 
 # directory in which zip file is unzipped ie. the working directory
 # to load the csv files from another location, set it here


### PR DESCRIPTION
#44 introduced an inadvertant change in the default mode for running view-metrics. This PR
restores the mode to "web".
