### PR TITLE
Added error handling for non-200 response codes from endpoints

### DIFF
--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQApiService.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQApiService.java
@@ -1,5 +1,6 @@
 package org.sonatype.cs.getmetrics.service;
 
+import org.slf4j.Logger;
 import org.sonatype.cs.getmetrics.util.NexusIqApiConnection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -7,7 +8,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URLConnection;
+import java.net.HttpURLConnection;
 
 import javax.json.Json;
 import javax.json.JsonReader;
@@ -29,11 +30,26 @@ public class NexusIQApiService {
     @Value("${iq.api}")
     private String iqApi;
 
+    private static Logger logger = org.slf4j.LoggerFactory.getLogger(NexusIQApiService.class);
+
     public void makeReport(CsvFileService cfs, String endPoint) throws IOException {
-        URLConnection urlConnection =
+        HttpURLConnection urlConnection =
                 NexusIqApiConnection.createAuthorisedUrlConnection(
                         iqUser, iqPasswd, iqUrl, iqApi, endPoint);
-        InputStream is = urlConnection.getInputStream();
+        InputStream is;
+        try {
+            is = urlConnection.getInputStream();
+        } catch (IOException e) {
+            logger.info(
+                    "IOException raised when trying to reach iqUrl [{}], iqApi [{}], endpoint [{}]"
+                            + " (return code [{} - {}]) - no CSV produced",
+                    iqUrl,
+                    iqApi,
+                    endPoint,
+                    urlConnection.getResponseCode(),
+                    urlConnection.getResponseMessage());
+            return;
+        }
         try (JsonReader reader = Json.createReader(is)) {
             cfs.makeCsvFile(fileIoService, reader);
         }


### PR DESCRIPTION
Before this PR calls to certain APIs failed with unclear reason given.

After this PR no CSV will be produced where a REST API call fails, the details
of the call and response code/reason from Nexus IQ will be presented in the output
and no CSV will be created. Execution of further REST API calls will continue 
after the failed call.
