### PR TITLE
Handle double quotes around time period data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ iqmetrics
 !get-metrics/src/test/java/org/sonatype/cs/getmetrics/resources/**
 !view-metrics/src/test/resources
 view-metrics/src/test/resources/org/sonatype/cs/metrics/*.received.txt
+application.properties

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQSuccessMetrics.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQSuccessMetrics.java
@@ -72,8 +72,10 @@ public class NexusIQSuccessMetrics {
     private String getPayload() throws IOException, JSONException, HttpException {
         log.info("Making api payload");
 
-        PayloadItem firstTimePeriod = new PayloadItem(iqApiFirstTimePeriod);
-        PayloadItem lastTimePeriod = new PayloadItem(iqApiLastTimePeriod);
+        PayloadItem firstTimePeriod =
+                new PayloadItem(UtilService.removeQuotesFromString(iqApiFirstTimePeriod));
+        PayloadItem lastTimePeriod =
+                new PayloadItem(UtilService.removeQuotesFromString(iqApiLastTimePeriod));
         PayloadItem organisationName = new PayloadItem(iqApiOrganisationName);
         PayloadItem applicationName = new PayloadItem(iqApiApplicationName);
 
@@ -83,7 +85,7 @@ public class NexusIQSuccessMetrics {
         }
 
         JSONObject ajson = new JSONObject();
-        ajson.put("timePeriod", iqSmPeriod.toUpperCase());
+        ajson.put("timePeriod", UtilService.removeQuotesFromString(iqSmPeriod.toUpperCase()));
         ajson.put("firstTimePeriod", firstTimePeriod.getItem());
 
         if (lastTimePeriod.isExists()) {

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/UtilService.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/UtilService.java
@@ -35,4 +35,14 @@ public class UtilService {
             writer.newLine();
         }
     }
+
+    public static String removeQuotesFromString(String inputString) {
+        if (inputString == null) {
+            return null;
+        }
+        if (inputString.startsWith("\"") && inputString.endsWith("\"")) {
+            return inputString.substring(1, inputString.length() - 1);
+        }
+        return inputString;
+    }
 }

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/util/UtilServiceTest.java
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/util/UtilServiceTest.java
@@ -49,4 +49,14 @@ public class UtilServiceTest {
         Assertions.assertEquals(
                 "first,second,third\nfourth,fifth,sixth\n", stringWriter.toString());
     }
+
+    @Test
+    void testRemoveQuotesFromString() {
+        Assertions.assertEquals("abc", UtilService.removeQuotesFromString("\"abc\""));
+        Assertions.assertEquals("abc", UtilService.removeQuotesFromString("abc"));
+        Assertions.assertEquals("\"abc", UtilService.removeQuotesFromString("\"abc"));
+        Assertions.assertEquals("abc\"", UtilService.removeQuotesFromString("abc\""));
+        Assertions.assertEquals("", UtilService.removeQuotesFromString("\"\""));
+        Assertions.assertEquals(null, UtilService.removeQuotesFromString(null));
+    }
 }


### PR DESCRIPTION
Before this PR get-metrics will fail if any of the values for these parameters are surrounded by double quotes:
iq.api.sm.period
iq.api.sm.payload.timeperiod.first
iq.api.sm.payload.timeperiod.last
(for example iq.api.sm.period="month").

After this PR the surrounding quotes are removed when sent to Nexus IQ and the application will not fail (for
this reason at least!).

This handling is not applied to other parameter values since there may be valid reasons for them containing
double quotes.
