### PR TITLE
Made NexusIqConnection into a service

### DIFF
--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQAPIPagingService.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQAPIPagingService.java
@@ -1,6 +1,5 @@
 package org.sonatype.cs.getmetrics.service;
 
-import org.sonatype.cs.getmetrics.util.NexusIqApiConnection;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +13,7 @@ import javax.json.JsonReader;
 
 @Service
 public class NexusIQAPIPagingService {
+    private NexusIqApiConnectionService nexusIqApiConnectionService;
     private FileIoService fileIoService;
     private String iqUrl;
     private String iqUser;
@@ -21,11 +21,13 @@ public class NexusIQAPIPagingService {
     private String iqApi;
 
     public NexusIQAPIPagingService(
+            NexusIqApiConnectionService nexusIqApiConnectionService,
             FileIoService fileIoService,
             @Value("${iq.url}") String iqUrl,
             @Value("${iq.user}") String iqUser,
             @Value("${iq.passwd}") String iqPasswd,
             @Value("${iq.api}") String iqApi) {
+        this.nexusIqApiConnectionService = nexusIqApiConnectionService;
         this.fileIoService = fileIoService;
         this.iqUrl = iqUrl;
         this.iqUser = iqUser;
@@ -41,7 +43,7 @@ public class NexusIQAPIPagingService {
 
         do {
             URLConnection urlConnection =
-                    NexusIqApiConnection.createAuthorizedPagedUrlConnection(
+                    nexusIqApiConnectionService.createAuthorizedPagedUrlConnection(
                             iqUser, iqPasswd, iqUrl, iqApi, endPoint, page, pageSize);
             InputStream is = urlConnection.getInputStream();
             JsonReader reader = Json.createReader(is);

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQApiDataService.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQApiDataService.java
@@ -1,6 +1,5 @@
 package org.sonatype.cs.getmetrics.service;
 
-import org.sonatype.cs.getmetrics.util.NexusIqApiConnection;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -14,16 +13,19 @@ import javax.json.JsonReader;
 
 @Service
 public class NexusIQApiDataService {
+    private NexusIqApiConnectionService nexusIqApiConnectionService;
     private String iqUrl;
     private String iqUser;
     private String iqPasswd;
     private String iqApi;
 
     public NexusIQApiDataService(
+            NexusIqApiConnectionService nexusIqApiConnectionService,
             @Value("${iq.url}") String iqUrl,
             @Value("${iq.user}") String iqUser,
             @Value("${iq.passwd}") String iqPasswd,
             @Value("${iq.api}") String iqApi) {
+        this.nexusIqApiConnectionService = nexusIqApiConnectionService;
         this.iqUrl = iqUrl;
         this.iqUser = iqUser;
         this.iqPasswd = iqPasswd;
@@ -32,7 +34,7 @@ public class NexusIQApiDataService {
 
     public JsonObject getData(String endPoint) throws IOException {
         HttpURLConnection urlConnection =
-                NexusIqApiConnection.createAuthorisedUrlConnection(
+                nexusIqApiConnectionService.createAuthorisedUrlConnection(
                         iqUser, iqPasswd, iqUrl, iqApi, endPoint);
 
         return getJsonReaderFromURLConnection(urlConnection);

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQApiService.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQApiService.java
@@ -1,7 +1,6 @@
 package org.sonatype.cs.getmetrics.service;
 
 import org.slf4j.Logger;
-import org.sonatype.cs.getmetrics.util.NexusIqApiConnection;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -17,6 +16,7 @@ public class NexusIQApiService {
 
     private static Logger logger = org.slf4j.LoggerFactory.getLogger(NexusIQApiService.class);
 
+    private NexusIqApiConnectionService nexusIqApiConnectionService;
     private FileIoService fileIoService;
     private String iqUrl;
     private String iqUser;
@@ -24,11 +24,13 @@ public class NexusIQApiService {
     private String iqApi;
 
     public NexusIQApiService(
+            NexusIqApiConnectionService nexusIqApiConnectionService,
             FileIoService fileIoService,
             @Value("${iq.url}") String iqUrl,
             @Value("${iq.user}") String iqUser,
             @Value("${iq.passwd}") String iqPasswd,
             @Value("${iq.api}") String iqApi) {
+        this.nexusIqApiConnectionService = nexusIqApiConnectionService;
         this.fileIoService = fileIoService;
         this.iqUrl = iqUrl;
         this.iqUser = iqUser;
@@ -38,7 +40,7 @@ public class NexusIQApiService {
 
     public void makeReport(CsvFileService cfs, String endPoint) throws IOException {
         HttpURLConnection urlConnection =
-                NexusIqApiConnection.createAuthorisedUrlConnection(
+                nexusIqApiConnectionService.createAuthorisedUrlConnection(
                         iqUser, iqPasswd, iqUrl, iqApi, endPoint);
         InputStream is;
         try {

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQSuccessMetrics.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQSuccessMetrics.java
@@ -15,7 +15,6 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.cs.getmetrics.model.PayloadItem;
-import org.sonatype.cs.getmetrics.util.NexusIqApiConnection;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 public class NexusIQSuccessMetrics {
     private static final Logger log = LoggerFactory.getLogger(NexusIQSuccessMetrics.class);
 
+    private NexusIqApiConnectionService nexusIqApiConnectionService;
     private FileIoService fileIoService;
 
     private String iqUrl;
@@ -40,6 +40,7 @@ public class NexusIQSuccessMetrics {
     private String iqReportsEndpoint;
 
     public NexusIQSuccessMetrics(
+            NexusIqApiConnectionService nexusIqApiConnectionService,
             FileIoService fileIoService,
             @Value("${iq.url}") String iqUrl,
             @Value("${iq.user}") String iqUser,
@@ -51,6 +52,7 @@ public class NexusIQSuccessMetrics {
             @Value("${iq.api.sm.payload.organisation.name}") String iqApiOrganisationName,
             @Value("${iq.api}") String iqApi,
             @Value("${iq.api.reports}") String iqReportsEndpoint) {
+        this.nexusIqApiConnectionService = nexusIqApiConnectionService;
         this.fileIoService = fileIoService;
         this.iqUrl = iqUrl;
         this.iqUser = iqUser;
@@ -68,7 +70,7 @@ public class NexusIQSuccessMetrics {
         String apiPayload = getPayload();
 
         String content =
-                NexusIqApiConnection.retrieveCsvBasedOnPayload(
+                nexusIqApiConnectionService.retrieveCsvBasedOnPayload(
                         iqUser, iqPwd, iqUrl, iqApi, iqReportsEndpoint, apiPayload);
         fileIoService.writeSuccessMetricsFile(
                 IOUtils.toInputStream(content, StandardCharsets.UTF_8));

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIqApiConnectionService.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIqApiConnectionService.java
@@ -1,8 +1,8 @@
-package org.sonatype.cs.getmetrics.util;
+package org.sonatype.cs.getmetrics.service;
 
 import org.apache.http.HttpException;
 import org.apache.tomcat.util.codec.binary.Base64;
-import org.sonatype.cs.getmetrics.service.UtilService;
+import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -10,15 +10,15 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.ProtocolException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 
-public class NexusIqApiConnection {
-    private NexusIqApiConnection() {}
+@Service
+class NexusIqApiConnectionService {
+    NexusIqApiConnectionService() {}
 
-    public static HttpURLConnection createAuthorisedUrlConnection(
+    public HttpURLConnection createAuthorisedUrlConnection(
             String user, String password, String url, String api, String endPoint)
             throws IOException {
         String encodedAuthString = createEncodedAuthString(user, password);
@@ -29,13 +29,13 @@ public class NexusIqApiConnection {
         return createUrlConnection(urlString, encodedAuthString);
     }
 
-    public static HttpURLConnection createAuthorisedUrlConnection(
+    public HttpURLConnection createAuthorisedUrlConnection(
             String user, String password, String urlString) throws IOException {
         String encodedAuthString = createEncodedAuthString(user, password);
         return createUrlConnection(urlString, encodedAuthString);
     }
 
-    public static HttpURLConnection createUrlConnection(String urlString, String encodedAuthString)
+    public HttpURLConnection createUrlConnection(String urlString, String encodedAuthString)
             throws IOException {
         URL url = new URL(urlString);
         HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
@@ -43,13 +43,13 @@ public class NexusIqApiConnection {
         return urlConnection;
     }
 
-    public static String createEncodedAuthString(String user, String password) {
+    public String createEncodedAuthString(String user, String password) {
         String authString = user + ":" + password;
         byte[] encodedAuth = Base64.encodeBase64(authString.getBytes(StandardCharsets.ISO_8859_1));
         return "Basic " + new String(encodedAuth);
     }
 
-    public static HttpURLConnection createAuthorizedPagedUrlConnection(
+    public HttpURLConnection createAuthorizedPagedUrlConnection(
             String user,
             String password,
             String url,
@@ -67,7 +67,7 @@ public class NexusIqApiConnection {
         return createUrlConnection(urlString, encodedAuthString);
     }
 
-    public static String retrieveCsvBasedOnPayload(
+    public String retrieveCsvBasedOnPayload(
             String user,
             String password,
             String url,
@@ -83,7 +83,7 @@ public class NexusIqApiConnection {
         return executeHttpURLPostForCSV(apiPayload, urlConnection);
     }
 
-    static String executeHttpURLPostForCSV(String apiPayload, HttpURLConnection urlConnection)
+    public String executeHttpURLPostForCSV(String apiPayload, HttpURLConnection urlConnection)
             throws IOException, HttpException {
         try (OutputStream connectionOutputStream = urlConnection.getOutputStream()) {
             byte[] payloadBytes = apiPayload.getBytes();
@@ -117,9 +117,9 @@ public class NexusIqApiConnection {
         return response;
     }
 
-    static HttpURLConnection prepareHttpURLPostForCSV(
+    public HttpURLConnection prepareHttpURLPostForCSV(
             String user, String password, String url, String api, String endpoint)
-            throws IOException, ProtocolException {
+            throws IOException {
         String metricsUrl = url + api + endpoint;
         HttpURLConnection urlConnection = createAuthorisedUrlConnection(user, password, metricsUrl);
         urlConnection.setRequestProperty("Accept", "text/csv");

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/reports/PolicyViolationsTest.java
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/reports/PolicyViolationsTest.java
@@ -99,7 +99,7 @@ public class PolicyViolationsTest {
     void testMakeCsvFile() {
         JsonObject jsonObject = null;
         NexusIQApiDataService nexusIQApiDataService =
-                new NexusIQApiDataService("URL", "USER", "PASSWORD", "API");
+                new NexusIQApiDataService(null, "URL", "USER", "PASSWORD", "API");
         PolicyIdsService policyIdsService = new PolicyIdsService(nexusIQApiDataService);
         PolicyViolations violations = new PolicyViolations(policyIdsService);
         Assertions.assertThrows(

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/service/NexusApiConnectionTest.java
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/service/NexusApiConnectionTest.java
@@ -1,4 +1,4 @@
-package org.sonatype.cs.getmetrics.util;
+package org.sonatype.cs.getmetrics.service;
 
 import static org.mockito.Mockito.*;
 
@@ -14,18 +14,21 @@ import java.net.ProtocolException;
 import java.net.URLConnection;
 
 public class NexusApiConnectionTest {
+    private NexusIqApiConnectionService nexusIqApiConnectionService =
+            new NexusIqApiConnectionService();
+
     @Test
     void testCreateEncodedAuthString() {
         Assertions.assertEquals(
                 "Basic dXNlcjpwYXNzd29yZA==",
-                NexusIqApiConnection.createEncodedAuthString("user", "password"));
+                nexusIqApiConnectionService.createEncodedAuthString("user", "password"));
     }
 
     @Test
     void testCreateUrlConnection() {
         try {
             URLConnection urlConnection =
-                    NexusIqApiConnection.createUrlConnection(
+                    nexusIqApiConnectionService.createUrlConnection(
                             "http://test.com/api/v2/test", "Basic dXNlcjpwYXNzd29yZA==");
             Assertions.assertEquals(
                     "http://test.com/api/v2/test", urlConnection.getURL().toString());
@@ -36,7 +39,7 @@ public class NexusApiConnectionTest {
         Assertions.assertThrows(
                 IOException.class,
                 () -> {
-                    NexusIqApiConnection.createUrlConnection(
+                    nexusIqApiConnectionService.createUrlConnection(
                             "http123://test.com/api/v2/test", "Basic dXNlcjpwYXNzd29yZA==");
                 });
     }
@@ -45,7 +48,7 @@ public class NexusApiConnectionTest {
     void testCreateAuthorisedUrlConnection() {
         try {
             URLConnection urlConnection =
-                    NexusIqApiConnection.createAuthorisedUrlConnection(
+                    nexusIqApiConnectionService.createAuthorisedUrlConnection(
                             "user", "password", "http://test.com", "/api/v2", "/test");
             Assertions.assertEquals(
                     "http://test.com/api/v2/test", urlConnection.getURL().toString());
@@ -58,7 +61,7 @@ public class NexusApiConnectionTest {
     void testCreateAuthorizedPagedUrlConnection() {
         try {
             URLConnection urlConnection =
-                    NexusIqApiConnection.createAuthorizedPagedUrlConnection(
+                    nexusIqApiConnectionService.createAuthorizedPagedUrlConnection(
                             "user", "password", "http://test.com", "/api/v2", "/test", 1, 50);
             Assertions.assertEquals(
                     "http://test.com/api/v2/test?page=1&pageSize=50&asc=true",
@@ -79,7 +82,8 @@ public class NexusApiConnectionTest {
         Assertions.assertThrows(
                 HttpException.class,
                 () -> {
-                    NexusIqApiConnection.executeHttpURLPostForCSV(apiPayload, mockedUrlConnection);
+                    nexusIqApiConnectionService.executeHttpURLPostForCSV(
+                            apiPayload, mockedUrlConnection);
                 });
 
         when(mockedUrlConnection.getOutputStream()).thenReturn(new ByteArrayOutputStream());
@@ -89,7 +93,8 @@ public class NexusApiConnectionTest {
         try {
             Assertions.assertEquals(
                     "{'1': '2'}",
-                    NexusIqApiConnection.executeHttpURLPostForCSV(apiPayload, mockedUrlConnection));
+                    nexusIqApiConnectionService.executeHttpURLPostForCSV(
+                            apiPayload, mockedUrlConnection));
         } catch (HttpException e) {
             Assertions.fail();
         }
@@ -100,7 +105,7 @@ public class NexusApiConnectionTest {
         HttpURLConnection urlConnection;
         try {
             urlConnection =
-                    NexusIqApiConnection.prepareHttpURLPostForCSV(
+                    nexusIqApiConnectionService.prepareHttpURLPostForCSV(
                             "user", "password", "http://test.com", "/api/v2", "/test");
             Assertions.assertEquals(
                     "http://test.com/api/v2/test", urlConnection.getURL().toString());


### PR DESCRIPTION
Before this PR connectivity to Nexus IQ was handled by a Java class with static functions. This worked fine
however made this class impossible to Mock when called from services.

After this PR the Nexus IQ connectivity class is a service and as such can be Mocked more easily.
