### PR TITLE
Bumped springframework.boot to 2.6.1

### DIFF
--- a/get-metrics/build.gradle
+++ b/get-metrics/build.gradle
@@ -1,7 +1,7 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
-	id 'org.springframework.boot' version '2.6.3'
+	id 'org.springframework.boot' version '2.6.1'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 }
 

--- a/view-metrics/build.gradle
+++ b/view-metrics/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.5.6'
+	id 'org.springframework.boot' version '2.6.1'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id "com.palantir.docker" version "0.22.1"
     id "io.freefair.lombok" version "6.3.0"

--- a/view-metrics/src/test/java/org/sonatype/cs/metrics/TestSuccessMetricsIsightsApplicationTo202106.java
+++ b/view-metrics/src/test/java/org/sonatype/cs/metrics/TestSuccessMetricsIsightsApplicationTo202106.java
@@ -7,7 +7,6 @@ import org.approvaltests.Approvals;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -19,8 +18,7 @@ import java.nio.file.Paths;
             "metrics.dir=src/test/resources",
             "spring.profiles.active=data",
             "data.successmetrics=successmetrics-2021-01-01-to-2021-06-01.csv"
-        },
-        webEnvironment = WebEnvironment.RANDOM_PORT)
+        })
 public class TestSuccessMetricsIsightsApplicationTo202106 {
 
     @Autowired private SuccessMetricsApplication controller;

--- a/view-metrics/src/test/java/org/sonatype/cs/metrics/TestSuccessMetricsIsightsApplicationTo202107.java
+++ b/view-metrics/src/test/java/org/sonatype/cs/metrics/TestSuccessMetricsIsightsApplicationTo202107.java
@@ -7,7 +7,6 @@ import org.approvaltests.Approvals;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -19,8 +18,7 @@ import java.nio.file.Paths;
             "metrics.dir=src/test/resources",
             "spring.profiles.active=data",
             "data.successmetrics=successmetrics-2021-01-01-to-2021-07-01.csv"
-        },
-        webEnvironment = WebEnvironment.RANDOM_PORT)
+        })
 public class TestSuccessMetricsIsightsApplicationTo202107 {
 
     @Autowired private SuccessMetricsApplication controller;


### PR DESCRIPTION
This PR is raised to bump springboot to 2.6.1 in preparation for any
incoming springboot patch for springshell. This also aligns springboot
versions between get-metrics and view-metrics.
