### PR TITLE
Deactivated H2 console by default

### DIFF
--- a/.github/workflows/develop_branch.yml
+++ b/.github/workflows/develop_branch.yml
@@ -51,7 +51,7 @@ jobs:
 
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          ./gradlew -Prelversion=$VERSION clean build test codeCoverageReport --info
+          ./gradlew -Prelversion=$VERSION clean build test codeCoverageReport --info --stacktrace
 
       - name: Generate JaCoCo Badge
         id: jacoco

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ subprojects{
       }
     }
 
+
   jacocoTestReport {
     reports{
       xml.enabled true

--- a/view-metrics/src/main/resources/application.properties
+++ b/view-metrics/src/main/resources/application.properties
@@ -20,7 +20,7 @@ data.includelatestperiod=false
 
 # Application properties
 server.port=4040
-spring.h2.console.enabled=true
+spring.h2.console.enabled=false
 spring.h2.console.path=/db
 spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_ON_EXIT=FALSE
 spring.jpa.show-sql=false

--- a/view-metrics/src/test/java/org/sonatype/cs/metrics/H2WebConsoleTest.java
+++ b/view-metrics/src/test/java/org/sonatype/cs/metrics/H2WebConsoleTest.java
@@ -1,0 +1,33 @@
+package org.sonatype.cs.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@DisplayName("The H2 console should")
+@SpringBootTest(
+        properties = {"metrics.dir=src/test/resources/iqmetrics", "spring.profiles.active=web"},
+        webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class H2WebConsoleTest {
+    @Value("${spring.h2.console.enabled}")
+    String h2ConsoleEnabled;
+
+    @Test
+    @DisplayName("not be enabled")
+    public void testH2ConsoleIsNotEnabled() {
+        assertNotEquals("true", h2ConsoleEnabled);
+    }
+
+    @Test
+    @DisplayName("be disabled")
+    public void testH2ConsoleIsDisabled() {
+        assertEquals("false", h2ConsoleEnabled);
+    }
+}


### PR DESCRIPTION
Before this PR the H2 database we console is available by default
at path "/db", this can present a security risk.

After this PR the H2 database is deactivated by default. It can be
activated by setting parameter `spring.h2.console.enabled` to true,
this can be useful in development or testing scenarios.
