### PR TITLE
Add command line parameters to wrapper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If both of these parameter are set then the organistaion setting will be used an
 
 ```bash
 cd get-metrics
-sh runapp.bat
+sh runapp.sh
 ```
 
 #### Get-metrics using Java on Windows machines
@@ -142,7 +142,7 @@ To configure which mode the view-metrics application should run in set the `spri
 
 ```bash
 cd view-metrics
-sh runapp.bat
+sh runapp.sh
 ```
 
 #### View-metrics using Java on Windows machines

--- a/get-metrics/releasefiles/runapp-docker.bat
+++ b/get-metrics/releasefiles/runapp-docker.bat
@@ -1,2 +1,2 @@
 @echo off
-docker run --rm -it -v %CD%/config:/config -v %CD%/../iqmetrics:/iqmetrics ghcr.io/sonatype-nexus-community/getmetrics:@APPVER@
+docker run --rm -it -v %CD%/config:/config -v %CD%/../iqmetrics:/iqmetrics ghcr.io/sonatype-nexus-community/getmetrics:@APPVER@ %*

--- a/get-metrics/releasefiles/runapp-docker.sh
+++ b/get-metrics/releasefiles/runapp-docker.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker run --rm -it -v "$PWD"/config:/config -v "$PWD"/../iqmetrics:/iqmetrics ghcr.io/sonatype-nexus-community/nexusiq-successmetrics-get-metrics:@APPVER@
+docker run --rm -it -v "$PWD"/config:/config -v "$PWD"/../iqmetrics:/iqmetrics ghcr.io/sonatype-nexus-community/nexusiq-successmetrics-get-metrics:@APPVER@ "$@"

--- a/get-metrics/releasefiles/runapp.bat
+++ b/get-metrics/releasefiles/runapp.bat
@@ -1,2 +1,2 @@
 
-java -jar get-metrics-@APPVER@.jar
+java -jar get-metrics-@APPVER@.jar %*

--- a/get-metrics/releasefiles/runapp.sh
+++ b/get-metrics/releasefiles/runapp.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+java -jar get-metrics-@APPVER@.jar "$@"

--- a/view-metrics/releasefiles/runapp-docker.bat
+++ b/view-metrics/releasefiles/runapp-docker.bat
@@ -1,2 +1,2 @@
 @echo off
-docker run -p 4040:4040 -v %CD%/config:/config -v %CD%/../iqmetrics:/iqmetrics ghcr.io/sonatype-nexus-community/nexusiq-successmetrics-view-metrics:@APPVER@
+docker run -p 4040:4040 -v %CD%/config:/config -v %CD%/../iqmetrics:/iqmetrics ghcr.io/sonatype-nexus-community/nexusiq-successmetrics-view-metrics:@APPVER@ %*

--- a/view-metrics/releasefiles/runapp-docker.sh
+++ b/view-metrics/releasefiles/runapp-docker.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -p 4040:4040 -v "$PWD"/config:/config -v "$PWD"/../iqmetrics/:/iqmetrics ghcr.io/sonatype-nexus-community/nexusiq-successmetrics-view-metrics:@APPVER@
+docker run -p 4040:4040 -v "$PWD"/config:/config -v "$PWD"/../iqmetrics/:/iqmetrics ghcr.io/sonatype-nexus-community/nexusiq-successmetrics-view-metrics:@APPVER@ "$@"

--- a/view-metrics/releasefiles/runapp.bat
+++ b/view-metrics/releasefiles/runapp.bat
@@ -1,2 +1,2 @@
 
-java -jar view-metrics-@APPVER@.jar
+java -jar view-metrics-@APPVER@.jar %*

--- a/view-metrics/releasefiles/runapp.sh
+++ b/view-metrics/releasefiles/runapp.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+java -jar view-metrics-@APPVER@.jar "$@"


### PR DESCRIPTION
Before this PR command line parameters cannot be given to the applications if the wrapper scripts are used (for example `runapp-docker.sh` or `runapp.bat`.

After this PR, the wrapper scripts support command line parameters. New command line scripts are required for `runapp.bat` on Linux and so `runapp.sh` is introduced.