### PR TITLE
Automatically delete Docker containers after run

### DIFF
--- a/view-metrics/releasefiles/runapp-docker.bat
+++ b/view-metrics/releasefiles/runapp-docker.bat
@@ -1,2 +1,2 @@
 @echo off
-docker run -p 4040:4040 -v %CD%/config:/config -v %CD%/../iqmetrics:/iqmetrics ghcr.io/sonatype-nexus-community/nexusiq-successmetrics-view-metrics:@APPVER@ %*
+docker run --rm -p 4040:4040 -v %CD%/config:/config -v %CD%/../iqmetrics:/iqmetrics ghcr.io/sonatype-nexus-community/nexusiq-successmetrics-view-metrics:@APPVER@ %*

--- a/view-metrics/releasefiles/runapp-docker.sh
+++ b/view-metrics/releasefiles/runapp-docker.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -p 4040:4040 -v "$PWD"/config:/config -v "$PWD"/../iqmetrics/:/iqmetrics ghcr.io/sonatype-nexus-community/nexusiq-successmetrics-view-metrics:@APPVER@ "$@"
+docker run --rm -p 4040:4040 -v "$PWD"/config:/config -v "$PWD"/../iqmetrics/:/iqmetrics ghcr.io/sonatype-nexus-community/nexusiq-successmetrics-view-metrics:@APPVER@ "$@"


### PR DESCRIPTION
Before this PR view-metrics docker containers persist after running either `runapp-docker.bat` or `runapp-docker.sh`. This can take up disk space on the host system

After this PR the behaviour is changed so that docker containers are deleted when the container is exited.
