### PR TITLE
Add option to bypass SSL handing

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ iq.passwd
 
 &#9888; If you are using the get-metrics Docker image on the Nexus IQ machine then you cannot use `127.0.0.1` in the iq.url. You should instead use `host.docker.internal`.
 
+##### Error validating the security certificate
+
+If you receive an error saying "There was a problem validating the security certificate provided by IQ. Aborting..." when running the script then there is an option to disable checking of the Nexus IQ security certificate by setting the `insecure.ssl` parameter to `true`. This setting will make the connection to the Nexus IQ server less secure by bypassing the following checks that the get-metrics script performs on every connection to the Nexus IQ server:
+
+- check that the server certificate is signed by a trusted authority
+- check that the server certificate contains the correct domain name of the Nexus IQ server
+- check that the server certificate has, and has not expired
+
+This option is provided for convenience. The more correct is to resolve the underlying issue, whether by adding the server certificate to your machine, using the servers name rather than IP address in the `iq.url` parameter or by confirming that the server certificate has not expired. How to perform these changes and checks is outside the scope of this application and varies by operating system.
+
 #### Time period for which data should be fetched
 
 Data may be collected in monthly or weekly periods by setting the `iq.api.sm.period` to either `month` or `week`.

--- a/get-metrics/application.properties
+++ b/get-metrics/application.properties
@@ -30,6 +30,11 @@ iq.api.sm.payload.timeperiod.last=
 iq.api.sm.payload.organisation.name=
 iq.api.sm.payload.application.name=
 
+# weaken the security of the connection to the IQ server by setting this to true
+# this can be useful if you don't have access to the IQ server's security certificate
+insecure.ssl=false
+
+
 
 iq.api=/api/v2
 iq.api.reports=/reports/metrics

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/GetMetricsApplication.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/GetMetricsApplication.java
@@ -4,10 +4,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.cs.getmetrics.reports.*;
 import org.sonatype.cs.getmetrics.service.*;
+import org.sonatype.cs.getmetrics.util.InsecureSSL;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import javax.net.ssl.SSLHandshakeException;
 
 @SpringBootApplication
 public class GetMetricsApplication implements CommandLineRunner {
@@ -23,6 +26,7 @@ public class GetMetricsApplication implements CommandLineRunner {
     private boolean waivers;
     private boolean policyviolations;
     private boolean firewall;
+    private boolean insecure;
 
     public GetMetricsApplication(
             PolicyIdsService policyIdsService,
@@ -34,7 +38,8 @@ public class GetMetricsApplication implements CommandLineRunner {
             @Value("${metrics.applicationsevaluations}") boolean applicationsevaluations,
             @Value("${metrics.waivers}") boolean waivers,
             @Value("${metrics.policyviolations}") boolean policyviolations,
-            @Value("${metrics.firewall}") boolean firewall) {
+            @Value("${metrics.firewall}") boolean firewall,
+            @Value("${insecure.ssl}") boolean insecure) {
         this.policyIdsService = policyIdsService;
         this.nexusIQAPIPagingService = nexusIQAPIPagingService;
         this.nexusIQApiService = nexusIQApiService;
@@ -45,6 +50,7 @@ public class GetMetricsApplication implements CommandLineRunner {
         this.waivers = waivers;
         this.policyviolations = policyviolations;
         this.firewall = firewall;
+        this.insecure = insecure;
     }
 
     public static void main(String[] args) {
@@ -57,39 +63,53 @@ public class GetMetricsApplication implements CommandLineRunner {
 
         fileIoService.initMetricsDir();
 
-        if (successmetrics) {
-            nexusIQSuccessMetrics.createSuccessMetricsCsvFile();
+        if (insecure) {
+            InsecureSSL.makeSSLConnectionsInsecure();
         }
 
-        if (applicationsevaluations) {
-            nexusIQApiService.makeReport(new ApplicationEvaluations(), "/reports/applications");
-        }
+        try {
+            if (successmetrics) {
+                nexusIQSuccessMetrics.createSuccessMetricsCsvFile();
+            }
 
-        if (waivers) {
-            nexusIQApiService.makeReport(new Waivers(), "/reports/components/waivers");
-        }
+            if (applicationsevaluations) {
+                nexusIQApiService.makeReport(new ApplicationEvaluations(), "/reports/applications");
+            }
 
-        if (policyviolations) {
-            nexusIQApiService.makeReport(
-                    new PolicyViolations(policyIdsService),
-                    policyIdsService.getPolicyIdsEndpoint());
-        }
+            if (waivers) {
+                nexusIQApiService.makeReport(new Waivers(), "/reports/components/waivers");
+            }
 
-        if (firewall) {
-            nexusIQApiService.makeReport(
-                    new AutoReleasedFromQuarantineConfig(),
-                    "/firewall/releaseQuarantine/configuration");
+            if (policyviolations) {
+                nexusIQApiService.makeReport(
+                        new PolicyViolations(policyIdsService),
+                        policyIdsService.getPolicyIdsEndpoint());
+            }
 
-            nexusIQApiService.makeReport(
-                    new AutoReleasedFromQuarantineSummary(), "/firewall/releaseQuarantine/summary");
-            nexusIQApiService.makeReport(
-                    new QuarantinedComponentsSummary(), "/firewall/quarantine/summary");
+            if (firewall) {
+                nexusIQApiService.makeReport(
+                        new AutoReleasedFromQuarantineConfig(),
+                        "/firewall/releaseQuarantine/configuration");
 
-            nexusIQAPIPagingService.makeReport(
-                    new QuarantinedComponents(), "/firewall/components/quarantined");
-            nexusIQAPIPagingService.makeReport(
-                    new AutoReleasedFromQuarantineComponents(),
-                    "/firewall/components/autoReleasedFromQuarantine");
+                nexusIQApiService.makeReport(
+                        new AutoReleasedFromQuarantineSummary(),
+                        "/firewall/releaseQuarantine/summary");
+                nexusIQApiService.makeReport(
+                        new QuarantinedComponentsSummary(), "/firewall/quarantine/summary");
+
+                nexusIQAPIPagingService.makeReport(
+                        new QuarantinedComponents(), "/firewall/components/quarantined");
+                nexusIQAPIPagingService.makeReport(
+                        new AutoReleasedFromQuarantineComponents(),
+                        "/firewall/components/autoReleasedFromQuarantine");
+            }
+        } catch (SSLHandshakeException e) {
+            log.error(
+                    "There was a problem validating the security certificate provided by IQ."
+                            + " Aborting...");
+            log.info(
+                    "To disable security certificate checking please specify"
+                            + " '--insecure.ssl=true'");
         }
     }
 }

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/util/InsecureSSL.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/util/InsecureSSL.java
@@ -1,0 +1,49 @@
+package org.sonatype.cs.getmetrics.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+public class InsecureSSL {
+
+    private InsecureSSL() {}
+
+    public static void makeSSLConnectionsInsecure()
+            throws NoSuchAlgorithmException, KeyManagementException {
+        Logger log = LoggerFactory.getLogger(InsecureSSL.class);
+        log.warn("Making SSL connections insecure");
+        TrustManager[] trustAllCerts =
+                new TrustManager[] {
+                    new X509TrustManager() {
+                        public X509Certificate[] getAcceptedIssuers() {
+                            return new X509Certificate[0];
+                        }
+
+                        @Override
+                        public void checkClientTrusted(X509Certificate[] arg0, String arg1)
+                                throws CertificateException {
+                            // Not implemented
+                        }
+
+                        @Override
+                        public void checkServerTrusted(X509Certificate[] arg0, String arg1)
+                                throws CertificateException {
+                            // Not implemented
+                        }
+                    }
+                };
+        SSLContext sc = SSLContext.getInstance("TLS");
+        sc.init(null, trustAllCerts, new java.security.SecureRandom());
+        HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+        log.warn("SSL connections are now insecure");
+    }
+}


### PR DESCRIPTION
Before this PR any attempt to use an insecure SSL connection would fail (whether through server certificate 
not being trusted, server domain name not matching the certificate or server certificate having expired).

After this PR a new option `insecure.ssl` is introduced which allows insecure SSL to be used (and the above
checks skipped).
