### PR TITLE
Add insecure.ssl parameter to get-metrics application.properties

### DIFF
--- a/get-metrics/src/main/resources/application.properties
+++ b/get-metrics/src/main/resources/application.properties
@@ -34,3 +34,4 @@ iq.api.sm.payload.application.name=
 iq.api=/api/v2
 iq.api.reports=/reports/metrics
 metricsDir=../iqmetrics
+insecure.ssl=false


### PR DESCRIPTION
Before this PR running get-metrics fails due to missing parameter insecure.ssl.

After this PR get-metrics runs correctly.
