### PR TITLE
Fixed failure on null policy violation reference

### DIFF
--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/reports/PolicyViolations.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/reports/PolicyViolations.java
@@ -95,11 +95,12 @@ public class PolicyViolations implements CsvFileService {
 
     static String getCVE(JsonArray reasons) {
         List<String> cves = new ArrayList<>();
-
         for (JsonObject reason : reasons.getValuesAs(JsonObject.class)) {
-            JsonObject reference = reason.getJsonObject("reference");
-            String cve = reference.getString("value");
-
+            String cve = "";
+            if (!reason.isNull("reference")) {
+                JsonObject reference = reason.getJsonObject("reference");
+                cve = reference.getString("value");
+            }
             if (!cves.contains(cve)) {
                 cves.add(cve);
             }

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/reports/PolicyViolationsTest.java
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/reports/PolicyViolationsTest.java
@@ -26,7 +26,7 @@ public class PolicyViolationsTest {
                             .readObject()
                             .getJsonArray("reasons");
             Assertions.assertEquals(
-                    "CVE-2021-43466:CVE-2016-1000027", PolicyViolations.getCVE(reasons));
+                    "CVE-2021-43466:CVE-2016-1000027:", PolicyViolations.getCVE(reasons));
         } catch (FileNotFoundException e) {
             Assertions.fail();
         }

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/resources/policyViolationsSecurityReasons.json
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/resources/policyViolationsSecurityReasons.json
@@ -20,6 +20,11 @@
                 "type": "SECURITY_VULNERABILITY_REFID",
                 "value": "CVE-2016-1000027"
             }
+        },
+        {
+            "reason": "Found component older than 1 years",
+            "reference": null
         }
+
     ]
 }


### PR DESCRIPTION
Before this PR get-metrics would fail to successfully process policy violations
without a CVE/Sonatype issue reference.

After this PR, get-metrics will give an empty reason where no issue reference
is received from Nexus IQ for policy violations.
