### PR TITLE
Convert quarantined component handling to JPA repository

### DIFF
--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/reports/QuarantinedComponents.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/reports/QuarantinedComponents.java
@@ -43,7 +43,7 @@ public class QuarantinedComponents implements CsvFileService {
             displayName = displayName.replace(" ", "");
             String repository = result.getString("repository");
             String quarantineDate = result.getString("quarantineDate");
-            String dateCleared = result.getString("dateCleared", "N/A");
+            String dateCleared = result.getString("dateCleared", "");
             boolean quarantined = result.getBoolean("quarantined");
 
             JsonObject componentIdentifier = result.getJsonObject("componentIdentifier");

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/reports/QuarantinedComponentsTest.java
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/reports/QuarantinedComponentsTest.java
@@ -39,7 +39,7 @@ public class QuarantinedComponentsTest {
                     new String[] {
                         "npm_proxy",
                         "2021-03-29T14:43:51.477+0000",
-                        "N/A",
+                        "",
                         "add-fedops:0.0.0",
                         "npm",
                         "true",

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/SuccessMetricsApplication.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/SuccessMetricsApplication.java
@@ -11,6 +11,7 @@ import org.springframework.boot.Banner;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -19,6 +20,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 @SpringBootApplication
+@EnableJpaRepositories
 public class SuccessMetricsApplication implements CommandLineRunner {
 
     private static final Logger log = LoggerFactory.getLogger(SuccessMetricsApplication.class);

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/controller/FirewallController.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/controller/FirewallController.java
@@ -2,12 +2,13 @@ package org.sonatype.cs.metrics.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sonatype.cs.metrics.model.DbRowStr;
-import org.sonatype.cs.metrics.service.DbService;
+import org.sonatype.cs.metrics.model.AutoReleasedFromQuarantineComponent;
+import org.sonatype.cs.metrics.model.QuarantinedComponent;
+import org.sonatype.cs.metrics.repository.AutoReleasedFromQuarantinedComponentRepository;
+import org.sonatype.cs.metrics.repository.QuarantinedComponentRepository;
 import org.sonatype.cs.metrics.service.FileIoService;
 import org.sonatype.cs.metrics.service.LoaderService;
 import org.sonatype.cs.metrics.util.DataLoaderParams;
-import org.sonatype.cs.metrics.util.SqlStatements;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -21,16 +22,22 @@ import java.util.List;
 public class FirewallController {
     private static final Logger log = LoggerFactory.getLogger(FirewallController.class);
 
-    private DbService dbService;
+    private QuarantinedComponentRepository quarantinedComponentRepository;
+    private AutoReleasedFromQuarantinedComponentRepository
+            autoReleasedFromQuarantineComponentRepository;
     private LoaderService loaderService;
     private String metricsDir;
 
     public FirewallController(
-            DbService dbService,
             LoaderService loaderService,
+            QuarantinedComponentRepository quarantinedComponentRepository,
+            AutoReleasedFromQuarantinedComponentRepository
+                    autoReleasedFromQuarantineComponentRepository,
             @Value("${metrics.dir}") String metricsDir) {
-        this.dbService = dbService;
         this.loaderService = loaderService;
+        this.quarantinedComponentRepository = quarantinedComponentRepository;
+        this.autoReleasedFromQuarantineComponentRepository =
+                autoReleasedFromQuarantineComponentRepository;
         this.metricsDir = metricsDir;
     }
 
@@ -40,15 +47,15 @@ public class FirewallController {
 
         /* Firewall list reports (loaded at startup) */
         if (loaderService.isQuarantinedComponentsLoaded()) {
-            List<DbRowStr> quarantinedComponents =
-                    dbService.runSqlStr(SqlStatements.QUARANTINEDCOMPONENTS);
+            List<QuarantinedComponent> quarantinedComponents =
+                    quarantinedComponentRepository.findAll();
             model.addAttribute("quarantinedComponents", quarantinedComponents);
             model.addAttribute("quarantinedComponentsData", !quarantinedComponents.isEmpty());
         }
 
         if (loaderService.isAutoreleasedFromQuarantineComponentsLoaded()) {
-            List<DbRowStr> autoReleasedFromQuarantinedComponents =
-                    dbService.runSqlStr(SqlStatements.AUTORELEASEDFROMQUARANTINEDCOMPONENTS);
+            List<AutoReleasedFromQuarantineComponent> autoReleasedFromQuarantinedComponents =
+                    autoReleasedFromQuarantineComponentRepository.findAll();
             model.addAttribute(
                     "autoReleasedFromQuarantinedComponents", autoReleasedFromQuarantinedComponents);
 

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/model/AutoReleasedFromQuarantineComponent.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/model/AutoReleasedFromQuarantineComponent.java
@@ -1,0 +1,43 @@
+package org.sonatype.cs.metrics.model;
+
+import com.opencsv.bean.CsvDate;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.sql.Timestamp;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+@Table(name = "AUTORELEASED_FROM_QUARANTINED_COMPONENTS")
+public class AutoReleasedFromQuarantineComponent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String repository;
+
+    @CsvDate(value = "yyyy-MM-dd'T'HH:mm:ss.SSS", writeFormat = "yyyy-MM-dd HH:mm:ss.SSS")
+    private Timestamp quarantineDate;
+
+    @CsvDate(value = "yyyy-MM-dd'T'HH:mm:ss.SSS", writeFormat = "yyyy-MM-dd HH:mm:ss.SSS")
+    private Timestamp dateCleared;
+
+    private String displayName;
+    private String format;
+    private Boolean quarantined;
+    private String policyName;
+    private Integer threatLevel;
+    private String reason;
+}

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/model/QuarantinedComponent.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/model/QuarantinedComponent.java
@@ -1,0 +1,43 @@
+package org.sonatype.cs.metrics.model;
+
+import com.opencsv.bean.CsvDate;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.sql.Timestamp;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+@Table(name = "QUARANTINED_COMPONENTS")
+public class QuarantinedComponent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String repository;
+
+    @CsvDate(value = "yyyy-MM-dd'T'HH:mm:ss.SSS", writeFormat = "yyyy-MM-dd HH:mm:ss.SSS")
+    private Timestamp quarantineDate;
+
+    @CsvDate(value = "yyyy-MM-dd'T'HH:mm:ss.SSS", writeFormat = "yyyy-MM-dd HH:mm:ss.SSS")
+    private Timestamp dateCleared;
+
+    private String displayName;
+    private String format;
+    private Boolean quarantined;
+    private String policyName;
+    private Integer threatLevel;
+    private String reason;
+}

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/repository/AutoReleasedFromQuarantinedComponentRepository.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/repository/AutoReleasedFromQuarantinedComponentRepository.java
@@ -1,0 +1,9 @@
+package org.sonatype.cs.metrics.repository;
+
+import org.sonatype.cs.metrics.model.AutoReleasedFromQuarantineComponent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AutoReleasedFromQuarantinedComponentRepository
+        extends JpaRepository<AutoReleasedFromQuarantineComponent, Long> {}

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/repository/QuarantinedComponentRepository.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/repository/QuarantinedComponentRepository.java
@@ -1,0 +1,8 @@
+package org.sonatype.cs.metrics.repository;
+
+import org.sonatype.cs.metrics.model.QuarantinedComponent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuarantinedComponentRepository extends JpaRepository<QuarantinedComponent, Long> {}

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/service/CsvToRepositoryService.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/service/CsvToRepositoryService.java
@@ -1,0 +1,43 @@
+package org.sonatype.cs.metrics.service;
+
+import com.opencsv.bean.CsvToBeanBuilder;
+import com.opencsv.enums.CSVReaderNullFieldIndicator;
+
+import org.sonatype.cs.metrics.repository.QuarantinedComponentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.logging.Logger;
+
+@Service
+public class CsvToRepositoryService {
+    @Autowired public QuarantinedComponentRepository quarantinedComponentRepository;
+    Logger log = Logger.getLogger(CsvToRepositoryService.class.getName());
+
+    public <T> Boolean load(String path, JpaRepository<T, Long> repository, Class<T> type)
+            throws IOException {
+        log.info(() -> "Loading file: " + path);
+        try {
+            List<T> allItems = readFromFile(Files.newBufferedReader(Paths.get(path)), type);
+            allItems.forEach(repository::save);
+            return repository.count() > 0;
+        } catch (IOException e) {
+            log.warning(() -> "File not found: " + path);
+        }
+        return false;
+    }
+
+    public <T> List<T> readFromFile(Reader reader, Class<T> type) {
+        return new CsvToBeanBuilder<T>(reader)
+                .withFieldAsNull(CSVReaderNullFieldIndicator.EMPTY_SEPARATORS)
+                .withType(type)
+                .build()
+                .parse();
+    }
+}

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/util/DataLoaderParams.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/util/DataLoaderParams.java
@@ -21,16 +21,12 @@ public class DataLoaderParams {
             "policyName,reason,applicationName,openTime,component,stage,threatLevel";
 
     public static final String QCDATAFILE = "quarantined_components.csv";
-    public static final String QCHEADER =
-            "repository,quarantineDate,dateCleared,displayName,format,quarantined,policyName,threatLevel,reason";
 
     public static final String QCSDATAFILE = "quarantined_components_summary.csv";
     public static final String QCSHEADER =
             "repositoryCount,quarantineEnabledCount,quarantineenabled,totalComponentCount,quarantinedComponentCount";
 
     public static final String AFQCDATAFILE = "autoreleased_from_quarantine_components.csv";
-    public static final String AFQCHEADER =
-            "repository,quarantineDate,dateCleared,displayName,format,quarantined,policyName,threatLevel,reason";
 
     public static final String AFQCSDATAFILE =
             "autoreleased_from_quarantine_components_summary.csv";

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/util/SqlStatements.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/util/SqlStatements.java
@@ -211,18 +211,6 @@ public class SqlStatements {
                     + " as pointD, threatLevel as pointE, comment as pointF, createDate as pointG,"
                     + " expiryTime as pointH from COMPONENT_WAIVER order by 1 asc";
 
-    public static final String QUARANTINEDCOMPONENTS =
-            "select repository as pointA, quarantineDate as pointB, dateCleared as pointC,"
-                + " displayName as pointD, format as pointE, quarantined as pointF, policyName as"
-                + " pointG, threatLevel as pointH, reason as pointI from QUARANTINED_COMPONENTS"
-                + " order by 6 asc";
-
-    public static final String AUTORELEASEDFROMQUARANTINEDCOMPONENTS =
-            "select repository as pointA, quarantineDate as pointB, dateCleared as pointC,"
-                + " displayName as pointD, format as pointE, quarantined as pointF, policyName as"
-                + " pointG, threatLevel as pointH, reason as pointI from"
-                + " AUTORELEASED_FROM_QUARANTINED_COMPONENTS order by 6 asc";
-
     public static final String METRICSTABLE =
             "DROP TABLE IF EXISTS METRIC; "
                     + "CREATE TABLE METRIC ("
@@ -339,24 +327,4 @@ public class SqlStatements {
                 + " (sum(OPEN_COUNT_AT_TIME_PERIOD_END_SECURITY_CRITICAL) +"
                 + " sum(OPEN_COUNT_AT_TIME_PERIOD_END_LICENSE_CRITICAL)) as pointA from <?> group"
                 + " by application_name order by 1";
-
-    public static final String QUARANTINEDCOMPONENTSTABLE =
-            "DROP TABLE IF EXISTS QUARANTINED_COMPONENTS;CREATE TABLE QUARANTINED_COMPONENTS ( "
-                + " repository VARCHAR(250) NOT NULL,  quarantineDate VARCHAR(250) NOT NULL, "
-                + " dateCleared VARCHAR(250) DEFAULT NULL,  displayName VARCHAR(250) DEFAULT NULL, "
-                + " format VARCHAR(250) DEFAULT NULL,  quarantined VARCHAR(1024) DEFAULT NULL, "
-                + " policyName VARCHAR(250) DEFAULT NULL,  threatLevel VARCHAR(250) DEFAULT NULL, "
-                + " reason VARCHAR(250) DEFAULT NULL)  AS SELECT repository, quarantineDate,"
-                + " dateCleared, displayName, format, quarantined, policyName, threatLevel, reason"
-                + " FROM CSVREAD ";
-
-    public static final String AUTORELEASEDFROMQUARANTINEDCOMPONENTSTABLE =
-            "DROP TABLE IF EXISTS AUTORELEASED_FROM_QUARANTINED_COMPONENTS;CREATE TABLE"
-                + " AUTORELEASED_FROM_QUARANTINED_COMPONENTS (  repository VARCHAR(250) NOT NULL, "
-                + " quarantineDate VARCHAR(250) NOT NULL,  dateCleared VARCHAR(250) DEFAULT NULL, "
-                + " displayName VARCHAR(250) DEFAULT NULL,  format VARCHAR(250) DEFAULT NULL, "
-                + " quarantined VARCHAR(1024) DEFAULT NULL,  policyName VARCHAR(250) DEFAULT NULL, "
-                + " threatLevel VARCHAR(250) DEFAULT NULL,  reason VARCHAR(250) DEFAULT NULL)  AS"
-                + " SELECT repository, quarantineDate, dateCleared, displayName, format,"
-                + " quarantined, policyName, threatLevel, reason FROM CSVREAD ";
 }

--- a/view-metrics/src/main/resources/templates/firewall.html
+++ b/view-metrics/src/main/resources/templates/firewall.html
@@ -98,15 +98,15 @@
             </thead>
             <tbody>
             <tr th:each="dp : ${quarantinedComponents}">
-                <td th:text="${dp.pointA}"></td>
-                <td th:text="${dp.pointB}"></td>
-                <td th:text="${dp.pointC}"></td>
-                <td th:text="${dp.pointD}"></td>
-                <td th:text="${dp.pointE}"></td>
-                <td th:text="${dp.pointF}"></td>
-                <td th:text="${dp.pointG}"></td>
-                <td th:text="${dp.pointH}"></td>
-                <td th:text="${dp.pointI}"></td>
+                <td th:text="${dp.repository}"></td>
+                <td th:text="${dp.quarantineDate}"></td>
+                <td th:text="${dp.dateCleared} ?: 'N/A'"></td>
+                <td th:text="${dp.displayName}"></td>
+                <td th:text="${dp.format}"></td>
+                <td th:text="${dp.quarantined}"></td>
+                <td th:text="${dp.policyName}"></td>
+                <td th:text="${dp.threatLevel}"></td>
+                <td th:text="${dp.reason}"></td>
 
             </tr>
             </tbody>
@@ -143,15 +143,15 @@
             </thead>
             <tbody>
             <tr th:each="dp : ${autoReleasedFromQuarantinedComponents}">
-                <td th:text="${dp.pointA}"></td>
-                <td th:text="${dp.pointB}"></td>
-                <td th:text="${dp.pointC}"></td>
-                <td th:text="${dp.pointD}"></td>
-                <td th:text="${dp.pointE}"></td>
-                <td th:text="${dp.pointF}"></td>
-                <td th:text="${dp.pointG}"></td>
-                <td th:text="${dp.pointH}"></td>
-                <td th:text="${dp.pointI}"></td>
+                <td th:text="${dp.repository}"></td>
+                <td th:text="${dp.quarantineDate}"></td>
+                <td th:text="${dp.dateCleared}"></td>
+                <td th:text="${dp.displayName}"></td>
+                <td th:text="${dp.format}"></td>
+                <td th:text="${dp.quarantined}"></td>
+                <td th:text="${dp.policyName}"></td>
+                <td th:text="${dp.threatLevel}"></td>
+                <td th:text="${dp.reason}"></td>
 
             </tr>
             </tbody>

--- a/view-metrics/src/test/resources/iqmetrics/autoreleased_from_quarantine_components.csv
+++ b/view-metrics/src/test/resources/iqmetrics/autoreleased_from_quarantine_components.csv
@@ -1,2 +1,2 @@
 repository,quarantineDate,dateCleared,displayName,format,quarantined,policyName,threatLevel,reason
-test_repo,2022-01-01,2022-01-02,test_display,test_format,test_quarantined,test_policy,10,test_reason
+test_repo,2021-10-13T11:11:43.500+0000,2021-10-13T11:11:43.500+0000,test_display,test_format,true,test_policy,10,test_reason

--- a/view-metrics/src/test/resources/iqmetrics/quarantined_components.csv
+++ b/view-metrics/src/test/resources/iqmetrics/quarantined_components.csv
@@ -1,6 +1,6 @@
 repository,quarantineDate,dateCleared,displayName,format,quarantined,policyName,threatLevel,reason
-maven-central-fw,2021-10-13T11:11:43.500+0000,N/A,com.sonatype.clm:clm-maven-plugin:2.19.0-01,maven,true,License-Not-Provided,9,
-maven-central-fw,2021-10-13T11:11:43.500+0000,N/A,com.sonatype.clm:clm-maven-plugin:2.19.0-01,maven,true,License-Banned,10,Proprietary-Clause
-maven-central-fw,2021-10-13T11:11:46.325+0000,N/A,com.sonatype.clm:clm-maven-plugin:2.18.0-01,maven,true,License-Not-Provided,9,
-maven-central-fw,2021-10-13T11:11:46.325+0000,N/A,com.sonatype.clm:clm-maven-plugin:2.18.0-01,maven,true,License-Banned,10,Proprietary-Clause
-maven-central-fw,2021-11-18T17:40:38.953+0000,N/A,org.apache.maven.plugins:maven-jar-plugin:2.4,maven,true,License-Banned,10,Apache-2.0
+maven-central-fw,2021-10-13T11:11:43.500+0000,,com.sonatype.clm:clm-maven-plugin:2.19.0-01,maven,true,License-Not-Provided,9,
+maven-central-fw,2021-10-13T11:11:43.500+0000,,com.sonatype.clm:clm-maven-plugin:2.19.0-01,maven,true,License-Banned,10,Proprietary-Clause
+maven-central-fw,2021-10-13T11:11:46.325+0000,,com.sonatype.clm:clm-maven-plugin:2.18.0-01,maven,true,License-Not-Provided,9,
+maven-central-fw,2021-10-13T11:11:46.325+0000,,com.sonatype.clm:clm-maven-plugin:2.18.0-01,maven,true,License-Banned,10,Proprietary-Clause
+maven-central-fw,2021-11-18T17:40:38.953+0000,,org.apache.maven.plugins:maven-jar-plugin:2.4,maven,true,License-Banned,10,Apache-2.0

--- a/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.firewall.html.approved.txt
+++ b/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.firewall.html.approved.txt
@@ -241,7 +241,7 @@
             <tbody>
             <tr>
                 <td>maven-central-fw</td>
-                <td>2021-10-13T11:11:43.500+0000</td>
+                <td>2021-10-13 11:11:43.5</td>
                 <td>N/A</td>
                 <td>com.sonatype.clm:clm-maven-plugin:2.19.0-01</td>
                 <td>maven</td>
@@ -253,7 +253,7 @@
             </tr>
             <tr>
                 <td>maven-central-fw</td>
-                <td>2021-10-13T11:11:43.500+0000</td>
+                <td>2021-10-13 11:11:43.5</td>
                 <td>N/A</td>
                 <td>com.sonatype.clm:clm-maven-plugin:2.19.0-01</td>
                 <td>maven</td>
@@ -265,7 +265,7 @@
             </tr>
             <tr>
                 <td>maven-central-fw</td>
-                <td>2021-10-13T11:11:46.325+0000</td>
+                <td>2021-10-13 11:11:46.325</td>
                 <td>N/A</td>
                 <td>com.sonatype.clm:clm-maven-plugin:2.18.0-01</td>
                 <td>maven</td>
@@ -277,7 +277,7 @@
             </tr>
             <tr>
                 <td>maven-central-fw</td>
-                <td>2021-10-13T11:11:46.325+0000</td>
+                <td>2021-10-13 11:11:46.325</td>
                 <td>N/A</td>
                 <td>com.sonatype.clm:clm-maven-plugin:2.18.0-01</td>
                 <td>maven</td>
@@ -289,7 +289,7 @@
             </tr>
             <tr>
                 <td>maven-central-fw</td>
-                <td>2021-11-18T17:40:38.953+0000</td>
+                <td>2021-11-18 17:40:38.953</td>
                 <td>N/A</td>
                 <td>org.apache.maven.plugins:maven-jar-plugin:2.4</td>
                 <td>maven</td>
@@ -334,11 +334,11 @@
             <tbody>
             <tr>
                 <td>test_repo</td>
-                <td>2022-01-01</td>
-                <td>2022-01-02</td>
+                <td>2021-10-13 11:11:43.5</td>
+                <td>2021-10-13 11:11:43.5</td>
                 <td>test_display</td>
                 <td>test_format</td>
-                <td>test_quarantined</td>
+                <td>true</td>
                 <td>test_policy</td>
                 <td>10</td>
                 <td>test_reason</td>


### PR DESCRIPTION
Before this PR the handling of quarantine component data (including autoreleased
components) was done using handcrafted SQL. This can be complex to use and hard to
troubleshoot.

After this PR quarantine component data uses native JPARepositories
which will make future work with this data simpler.
