### PR TITLE
Fixed issue with missing quarantine components

### DIFF
--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/reports/AutoReleasedFromQuarantineComponents.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/reports/AutoReleasedFromQuarantineComponents.java
@@ -52,30 +52,45 @@ public class AutoReleasedFromQuarantineComponents implements CsvFileService {
 
             JsonArray quarantinePolicyViolations =
                     result.getJsonArray("quarantinePolicyViolations");
-            for (JsonObject quarantinePolicyViolation :
-                    quarantinePolicyViolations.getValuesAs(JsonObject.class)) {
-                String policyName = quarantinePolicyViolation.getString("policyName");
-                int threatLevel = quarantinePolicyViolation.getInt("threatLevel");
+            if (quarantinePolicyViolations.getValuesAs(JsonObject.class).isEmpty()) {
+                String[] line = {
+                    repository,
+                    quarantineDate,
+                    dateCleared,
+                    displayName,
+                    format,
+                    String.valueOf(quarantined),
+                    "None",
+                    "0",
+                    ""
+                };
+                data.add(line);
+            } else {
+                for (JsonObject quarantinePolicyViolation :
+                        quarantinePolicyViolations.getValuesAs(JsonObject.class)) {
+                    String policyName = quarantinePolicyViolation.getString("policyName");
+                    int threatLevel = quarantinePolicyViolation.getInt("threatLevel");
 
-                JsonArray constraintViolations =
-                        quarantinePolicyViolation.getJsonArray("constraintViolations");
-                for (JsonObject constraintViolation :
-                        constraintViolations.getValuesAs(JsonObject.class)) {
-                    JsonArray reasons = constraintViolation.getJsonArray("reasons");
-                    String reason = ParseReasons.getReason(policyName, reasons);
+                    JsonArray constraintViolations =
+                            quarantinePolicyViolation.getJsonArray("constraintViolations");
+                    for (JsonObject constraintViolation :
+                            constraintViolations.getValuesAs(JsonObject.class)) {
+                        JsonArray reasons = constraintViolation.getJsonArray("reasons");
+                        String reason = ParseReasons.getReason(policyName, reasons);
 
-                    String[] line = {
-                        repository,
-                        quarantineDate,
-                        dateCleared,
-                        displayName,
-                        format,
-                        String.valueOf(quarantined),
-                        policyName,
-                        String.valueOf(threatLevel),
-                        reason
-                    };
-                    data.add(line);
+                        String[] line = {
+                            repository,
+                            quarantineDate,
+                            dateCleared,
+                            displayName,
+                            format,
+                            String.valueOf(quarantined),
+                            policyName,
+                            String.valueOf(threatLevel),
+                            reason
+                        };
+                        data.add(line);
+                    }
                 }
             }
         }

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/reports/QuarantinedComponents.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/reports/QuarantinedComponents.java
@@ -51,30 +51,45 @@ public class QuarantinedComponents implements CsvFileService {
 
             JsonArray quarantinePolicyViolations =
                     result.getJsonArray("quarantinePolicyViolations");
-            for (JsonObject quarantinePolicyViolation :
-                    quarantinePolicyViolations.getValuesAs(JsonObject.class)) {
-                String policyName = quarantinePolicyViolation.getString("policyName");
-                int threatLevel = quarantinePolicyViolation.getInt("threatLevel");
+            if (quarantinePolicyViolations.getValuesAs(JsonObject.class).isEmpty()) {
+                String[] line = {
+                    repository,
+                    quarantineDate,
+                    dateCleared,
+                    displayName,
+                    format,
+                    String.valueOf(quarantined),
+                    "None",
+                    "0",
+                    ""
+                };
+                data.add(line);
+            } else {
+                for (JsonObject quarantinePolicyViolation :
+                        quarantinePolicyViolations.getValuesAs(JsonObject.class)) {
+                    String policyName = quarantinePolicyViolation.getString("policyName");
+                    int threatLevel = quarantinePolicyViolation.getInt("threatLevel");
 
-                JsonArray constraintViolations =
-                        quarantinePolicyViolation.getJsonArray("constraintViolations");
-                for (JsonObject constraintViolation :
-                        constraintViolations.getValuesAs(JsonObject.class)) {
-                    JsonArray reasons = constraintViolation.getJsonArray("reasons");
-                    String reason = ParseReasons.getReason(policyName, reasons);
+                    JsonArray constraintViolations =
+                            quarantinePolicyViolation.getJsonArray("constraintViolations");
+                    for (JsonObject constraintViolation :
+                            constraintViolations.getValuesAs(JsonObject.class)) {
+                        JsonArray reasons = constraintViolation.getJsonArray("reasons");
+                        String reason = ParseReasons.getReason(policyName, reasons);
 
-                    String[] line = {
-                        repository,
-                        quarantineDate,
-                        dateCleared,
-                        displayName,
-                        format,
-                        String.valueOf(quarantined),
-                        policyName,
-                        String.valueOf(threatLevel),
-                        reason
-                    };
-                    data.add(line);
+                        String[] line = {
+                            repository,
+                            quarantineDate,
+                            dateCleared,
+                            displayName,
+                            format,
+                            String.valueOf(quarantined),
+                            policyName,
+                            String.valueOf(threatLevel),
+                            reason
+                        };
+                        data.add(line);
+                    }
                 }
             }
         }

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/reports/AutoReleasedFromQuarantineComponentsTest.java
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/reports/AutoReleasedFromQuarantineComponentsTest.java
@@ -58,12 +58,25 @@ public class AutoReleasedFromQuarantineComponentsTest {
                     "9",
                     "Integrity-Rating"
                 };
+        String[] dataRow3 =
+                new String[] {
+                    "npm_proxy",
+                    "2021-03-24T14:45:02.567+0000",
+                    "2021-03-24T18:53:46.115+0000",
+                    "rc-util:5.9.6",
+                    "npm",
+                    "false",
+                    "None",
+                    "0",
+                    ""
+                };
         List<String[]> data =
                 AutoReleasedFromQuarantineComponents.getQuarantinedComponentsFromData(jsonObject);
-        Assertions.assertEquals(3, data.size());
+        Assertions.assertEquals(4, data.size());
         Assertions.assertArrayEquals(headerRow, data.get(0));
         Assertions.assertArrayEquals(dataRow1, data.get(1));
         Assertions.assertArrayEquals(dataRow2, data.get(2));
+        Assertions.assertArrayEquals(dataRow3, data.get(3));
     }
 
     @Test

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/reports/QuarantinedComponentsTest.java
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/reports/QuarantinedComponentsTest.java
@@ -47,11 +47,24 @@ public class QuarantinedComponentsTest {
                         "9",
                         "Integrity-Rating"
                     };
+            String[] dataRow2 =
+                    new String[] {
+                        "maven-central",
+                        "2022-03-16T14:11:09.146+0000",
+                        "",
+                        "commons-collections:commons-collections:3.1",
+                        "maven",
+                        "true",
+                        "None",
+                        "0",
+                        ""
+                    };
             List<String[]> data =
                     QuarantinedComponents.getQuarentinedComponentsFromData(jsonObject);
-            Assertions.assertEquals(2, data.size());
+            Assertions.assertEquals(3, data.size());
             Assertions.assertArrayEquals(headerRow, data.get(0));
             Assertions.assertArrayEquals(dataRow1, data.get(1));
+            Assertions.assertArrayEquals(dataRow2, data.get(2));
         } catch (FileNotFoundException e) {
             Assertions.fail();
         }

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/resources/autoReleasedFromQuarantineCompononts.json
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/resources/autoReleasedFromQuarantineCompononts.json
@@ -79,6 +79,25 @@
             "matchState": "exact",
             "repositoryId": "298bf707fd4f4323b7a0200b8dddd201",
             "quarantined": false
+        },
+        {
+            "displayName": "rc-util : 5.9.6",
+            "repository": "npm_proxy",
+            "quarantineDate": "2021-03-24T14:45:02.567+0000",
+            "dateCleared": "2021-03-24T18:53:46.115+0000",
+            "quarantinePolicyViolations": [],
+            "componentIdentifier": {
+                "format": "npm",
+                "coordinates": {
+                    "packageId": "rc-util",
+                    "version": "1.2.0"
+                }
+            },
+            "pathname": "rc-util/-/rc-util-5.9.6.tgz",
+            "hash": "b3e3c46f8a404334a2b3a5633d4f0be7",
+            "matchState": "exact",
+            "repositoryId": "298bf707fd4f4323b7a0200b8dddd201",
+            "quarantined": false
         }
     ]
 }

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/resources/quarantinedComponents.json
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/resources/quarantinedComponents.json
@@ -41,6 +41,28 @@
             "matchState": "exact",
             "repositoryId": "298bf707fd4f4323b7a0200b8dddd201",
             "quarantined": true
+        },
+        {
+            "displayName": "commons-collections : commons-collections : 3.1",
+            "repository": "maven-central",
+            "quarantineDate": "2022-03-16T14:11:09.146+0000",
+            "dateCleared": null,
+            "quarantinePolicyViolations": [],
+            "componentIdentifier": {
+                "format": "maven",
+                "coordinates": {
+                    "artifactId": "commons-collections",
+                    "classifier": "",
+                    "extension": "jar",
+                    "groupId": "commons-collections",
+                    "version": "3.1"
+                }
+            },
+            "pathname": "commons-collections/commons-collections/3.1/commons-collections-3.1.jar",
+            "hash": "40fb048097caeacdb11d",
+            "matchState": "exact",
+            "repositoryId": "4a7b99f9a0294d3682632b525b807156",
+            "quarantined": true
         }
     ]
 }


### PR DESCRIPTION
Before this PR some quarantine components were missing from `autoreleased_from_quarantine_components.csv`
and `quarantined_components.csv` because the REST API response from IQ did not contain any information
giving reason.

After this PR the quarantined components are included in the CSV with a policy name of "None", a 
threadLevel of of 0 and an empty reason field.
