### PR TITLE
Added table showing quarantined components by format and threat level

### DIFF
--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/model/AutoReleasedFromQuarantineComponent.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/model/AutoReleasedFromQuarantineComponent.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -28,11 +28,11 @@ public class AutoReleasedFromQuarantineComponent {
 
     private String repository;
 
-    @CsvDate(value = "yyyy-MM-dd'T'HH:mm:ss.SSS", writeFormat = "yyyy-MM-dd HH:mm:ss.SSS")
-    private Timestamp quarantineDate;
+    @CsvDate(value = "yyyy-MM-dd'T'HH:mm:ss.SSSX", writeFormat = "yyyy-MM-dd HH:mm")
+    private LocalDateTime quarantineDate;
 
-    @CsvDate(value = "yyyy-MM-dd'T'HH:mm:ss.SSS", writeFormat = "yyyy-MM-dd HH:mm:ss.SSS")
-    private Timestamp dateCleared;
+    @CsvDate(value = "yyyy-MM-dd'T'HH:mm:ss.SSSX", writeFormat = "yyyy-MM-dd HH:mm")
+    private LocalDateTime dateCleared;
 
     private String displayName;
     private String format;

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/model/QuarantinedComponent.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/model/QuarantinedComponent.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -28,11 +28,11 @@ public class QuarantinedComponent {
 
     private String repository;
 
-    @CsvDate(value = "yyyy-MM-dd'T'HH:mm:ss.SSS", writeFormat = "yyyy-MM-dd HH:mm:ss.SSS")
-    private Timestamp quarantineDate;
+    @CsvDate(value = "yyyy-MM-dd'T'HH:mm:ss.SSSX", writeFormat = "yyyy-MM-dd HH:mm")
+    private LocalDateTime quarantineDate;
 
-    @CsvDate(value = "yyyy-MM-dd'T'HH:mm:ss.SSS", writeFormat = "yyyy-MM-dd HH:mm:ss.SSS")
-    private Timestamp dateCleared;
+    @CsvDate(value = "yyyy-MM-dd'T'HH:mm:ss.SSSX", writeFormat = "yyyy-MM-dd HH:mm")
+    private LocalDateTime dateCleared;
 
     private String displayName;
     private String format;

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/repository/AutoReleasedFromQuarantinedComponentRepository.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/repository/AutoReleasedFromQuarantinedComponentRepository.java
@@ -2,8 +2,14 @@ package org.sonatype.cs.metrics.repository;
 
 import org.sonatype.cs.metrics.model.AutoReleasedFromQuarantineComponent;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface AutoReleasedFromQuarantinedComponentRepository
-        extends JpaRepository<AutoReleasedFromQuarantineComponent, Long> {}
+        extends JpaRepository<AutoReleasedFromQuarantineComponent, Long> {
+    @Query("SELECT DISTINCT displayName FROM AutoReleasedFromQuarantineComponent")
+    List<String> findDistinctDisplayName();
+}

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/repository/QuarantinedComponentRepository.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/repository/QuarantinedComponentRepository.java
@@ -2,7 +2,33 @@ package org.sonatype.cs.metrics.repository;
 
 import org.sonatype.cs.metrics.model.QuarantinedComponent;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Repository
-public interface QuarantinedComponentRepository extends JpaRepository<QuarantinedComponent, Long> {}
+public interface QuarantinedComponentRepository extends JpaRepository<QuarantinedComponent, Long> {
+    QuarantinedComponent findTop1ByOrderByQuarantineDateAsc();
+
+    QuarantinedComponent findTop1ByOrderByQuarantineDateDesc();
+
+    QuarantinedComponent findTop1ByOrderByDateClearedAsc();
+
+    QuarantinedComponent findTop1ByOrderByDateClearedDesc();
+
+    @Query("SELECT DISTINCT displayName FROM QuarantinedComponent ORDER BY displayName ASC")
+    List<String> findDistinctDisplayName();
+
+    @Query("SELECT DISTINCT format FROM QuarantinedComponent ORDER BY format ASC")
+    List<String> findDistinctFormat();
+
+    Long countByFormatAndThreatLevel(String format, Integer threatLevel);
+
+    @Query(
+            "SELECT COUNT(*) From QuarantinedComponent WHERE threatLevel = ?1 AND quarantineDate >="
+                    + " ?2 AND quarantineDate<= ?3")
+    Long countByThreatLevelByQuarantineDateBetween(
+            Integer threatLevel, LocalDateTime start, LocalDateTime end);
+}

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/util/HelperService.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/util/HelperService.java
@@ -89,4 +89,14 @@ public class HelperService {
         long tmp = Math.round(value);
         return (float) tmp / factor;
     }
+
+    public static LocalDateTime latestDate(LocalDateTime value1, LocalDateTime value2) {
+        if (value1 == null) {
+            return value2;
+        }
+        if (value2 == null) {
+            return value1;
+        }
+        return value1.isAfter(value2) ? value1 : value2;
+    }
 }

--- a/view-metrics/src/main/resources/application.properties
+++ b/view-metrics/src/main/resources/application.properties
@@ -26,6 +26,7 @@ spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_ON_EXIT=FALSE
 spring.jpa.show-sql=false
 spring.main.banner-mode=off
 spring.jpa.open-in-view=false
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.datasource.username=user
 spring.datasource.password=password
 sm.database=false

--- a/view-metrics/src/main/resources/templates/firewall.html
+++ b/view-metrics/src/main/resources/templates/firewall.html
@@ -1,167 +1,248 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<html>
+  <head>
+    <title>Firewall report</title>
+    <div th:insert="header :: headerFrag"></div>
+  </head>
 
-<head>
-<div th:insert="header :: headerFrag"></div>
-</head>
+  <body>
+    <div class="jumbotron">
+      <h4>Firewall Report</h4>
+    </div>
 
-   <body>
-
-        <div class="jumbotron">
-        <h4>Firewall Report</h4>
-        </div>
-
-        <div class="container">
-        <div class="row">
+    <div class="container">
+      <div class="row">
         <div class="col-xl mx-auto w-auto bg-white rounded">
+          <h5>Quarantined Components Summary Report</h5>
 
-        <h5>Quarantined Components Summary Report</h5>
-
-        <table class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
-        <thead class="tablecolumncolor">
-            <tr>
+          <table class="table table-striped table-bordered table-sm">
+            <caption>
+              Summary information about Firewall usage
+            </caption>
+            <thead class="tablecolumncolor">
+              <tr>
                 <th class="th-sm">Repository Count</th>
                 <th class="th-sm">Quarantine Enabled RepositoryCount</th>
                 <th class="th-sm">Quarantine Enabled</th>
                 <th class="th-sm">Total Component Count</th>
                 <th class="th-sm">Quarantined Component Count</th>
-            </tr>
+              </tr>
             </thead>
             <tbody>
-            <tr>
+              <tr>
                 <td th:text="${quarantinedComponentsSummary[0]}"></td>
                 <td th:text="${quarantinedComponentsSummary[1]}"></td>
                 <td th:text="${quarantinedComponentsSummary[2]}"></td>
                 <td th:text="${quarantinedComponentsSummary[3]}"></td>
                 <td th:text="${quarantinedComponentsSummary[4]}"></td>
-            </tr>
+              </tr>
             </tbody>
-        </table>
+          </table>
+        </div>
+      </div>
+    </div>
+    <br /><br />
 
-        </div>
-        </div>
-        </div>
-        </div>
-
-        <br><br>
-
-        <div class="container">
-        <div class="row">
+    <div class="container">
+      <div class="row">
         <div class="col-xl mx-auto w-auto bg-white rounded">
+          <h5>Autoreleased Quarantined Components Summary Report</h5>
 
-        <h5>Autoreleased Quarantined Components Summary Report</h5>
-
-        <table class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
-        <thead class="tablecolumncolor">
-            <tr>
+          <table class="table table-striped table-bordered table-sm">
+            <caption>
+              Summary of autoreleased components
+            </caption>
+            <thead class="tablecolumncolor">
+              <tr>
                 <th class="th-sm">AutoRelease Quarantine Count (MTD)</th>
                 <th class="th-sm">AutoRelease Quarantine Count (YTD)</th>
-            </tr>
+              </tr>
             </thead>
             <tbody>
-            <tr>
+              <tr>
                 <td th:text="${autoReleasedFromQuarantinedComponentsSummary[0]}"></td>
                 <td th:text="${autoReleasedFromQuarantinedComponentsSummary[1]}"></td>
-            </tr>
+              </tr>
             </tbody>
-        </table>
+          </table>
+        </div>
+      </div>
+    </div>
+    <br /><br />
 
-        </div>
-        </div>
-        </div>
-        </div>
-
-        <br><br>
-
-        <div class="container" th:if="${quarantinedComponentsData}">
-        <div class="row">
+    <div class="container">
+      <div class="row">
         <div class="col-xl mx-auto w-auto bg-white rounded">
-        <div class="table-responsive table-wrapper-scroll-y custom-scrollbar">
+          <h5>Quarantined Threat Level By Format</h5>
 
-        <h5>Quarantined Components Report</h5>
-
-        <table class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
-        <thead class="tablecolumncolor">
-            <tr>
-                <th class="th-sm">Repository</th>
-                <th class="th-sm">Quarantine Date</th>
-                <th class="th-sm">Date Cleared</th>
-                <th class="th-sm">Package Name</th>
+          <table class="table table-striped table-bordered table-sm">
+            <caption>
+              The number of quarantined violations by threat level sorted by format of the package with the violation.
+            </caption>
+            <thead class="tablecolumncolor">
+              <tr>
                 <th class="th-sm">Format</th>
-                <th class="th-sm">Quarantined</th>
-                <th class="th-sm">Policy Name</th>
-                <th class="th-sm">Threat Level</th>
-                <th class="th-sm">Reason</th>
-
-            </tr>
+                <th class="th-sm">Threat 10</th>
+                <th class="th-sm">Threat 9</th>
+                <th class="th-sm">Threat 8</th>
+                <th class="th-sm">Threat 7</th>
+                <th class="th-sm">Threat 6</th>
+                <th class="th-sm">Threat 5</th>
+                <th class="th-sm">Threat 4</th>
+                <th class="th-sm">Threat 3</th>
+                <th class="th-sm">Threat 2</th>
+                <th class="th-sm">Threat 1</th>
+                <th class="th-sm">Threat 0</th>
+              </tr>
             </thead>
             <tbody>
-            <tr th:each="dp : ${quarantinedComponents}">
-                <td th:text="${dp.repository}"></td>
-                <td th:text="${dp.quarantineDate}"></td>
-                <td th:text="${dp.dateCleared} ?: 'N/A'"></td>
-                <td th:text="${dp.displayName}"></td>
-                <td th:text="${dp.format}"></td>
-                <td th:text="${dp.quarantined}"></td>
-                <td th:text="${dp.policyName}"></td>
-                <td th:text="${dp.threatLevel}"></td>
-                <td th:text="${dp.reason}"></td>
-
-            </tr>
+              <tr th:each="dp: ${quarantinedComponentsFormatVulnerabilityCounts}">
+                <td th:text="${dp.key}"></td>
+                <td th:text="${dp.value[10]}"></td>
+                <td th:text="${dp.value[9]}"></td>
+                <td th:text="${dp.value[8]}"></td>
+                <td th:text="${dp.value[7]}"></td>
+                <td th:text="${dp.value[6]}"></td>
+                <td th:text="${dp.value[5]}"></td>
+                <td th:text="${dp.value[4]}"></td>
+                <td th:text="${dp.value[3]}"></td>
+                <td th:text="${dp.value[2]}"></td>
+                <td th:text="${dp.value[1]}"></td>
+                <td th:text="${dp.value[0]}"></td>
+              </tr>
             </tbody>
-        </table>
+          </table>
+        </div>
+      </div>
+    </div>
+    <br /><br />
 
-        </div>
-        </div>
-        </div>
-        </div>
-
-        <br><br>
-
-        <div class="container" th:if="${autoReleasedFromQuarantinedComponentsData}">
-        <div class="row">
+    <div class="container">
+      <div class="row">
         <div class="col-xl mx-auto w-auto bg-white rounded">
-        <div class="table-responsive table-wrapper-scroll-y custom-scrollbar">
+          <h5>Quarantined Threat Level By Month Raised</h5>
 
-        <h5>Autoreleased from Quarantined Components Report</h5>
-
-        <table class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
-        <thead class="tablecolumncolor">
-            <tr>
-                <th class="th-sm">Repository</th>
-                <th class="th-sm">Quarantine Date</th>
-                <th class="th-sm">Date Cleared</th>
-                <th class="th-sm">Package Name</th>
-                <th class="th-sm">Format</th>
-                <th class="th-sm">Quarantined</th>
-                <th class="th-sm">Policy Name</th>
-                <th class="th-sm">Threat Level</th>
-                <th class="th-sm">Reason</th>
-
-            </tr>
+          <table class="table table-striped table-bordered table-sm">
+            <caption>
+              The number of quarantined violations by threat level sorted by month the packages was put in quarantine.
+            </caption>
+            <thead class="tablecolumncolor">
+              <tr>
+                <th class="th-sm">Month</th>
+                <th class="th-sm">Threat 10</th>
+                <th class="th-sm">Threat 9</th>
+                <th class="th-sm">Threat 8</th>
+                <th class="th-sm">Threat 7</th>
+                <th class="th-sm">Threat 6</th>
+                <th class="th-sm">Threat 5</th>
+                <th class="th-sm">Threat 4</th>
+                <th class="th-sm">Threat 3</th>
+                <th class="th-sm">Threat 2</th>
+                <th class="th-sm">Threat 1</th>
+                <th class="th-sm">Threat 0</th>
+              </tr>
             </thead>
             <tbody>
-            <tr th:each="dp : ${autoReleasedFromQuarantinedComponents}">
-                <td th:text="${dp.repository}"></td>
-                <td th:text="${dp.quarantineDate}"></td>
-                <td th:text="${dp.dateCleared}"></td>
-                <td th:text="${dp.displayName}"></td>
-                <td th:text="${dp.format}"></td>
-                <td th:text="${dp.quarantined}"></td>
-                <td th:text="${dp.policyName}"></td>
-                <td th:text="${dp.threatLevel}"></td>
-                <td th:text="${dp.reason}"></td>
-
-            </tr>
+              <tr th:each="dp: ${quarantinedComponentMonthlyThreatCounts}">
+                <td th:text="${dp.key}"></td>
+                <td th:text="${dp.value[10]}"></td>
+                <td th:text="${dp.value[9]}"></td>
+                <td th:text="${dp.value[8]}"></td>
+                <td th:text="${dp.value[7]}"></td>
+                <td th:text="${dp.value[6]}"></td>
+                <td th:text="${dp.value[5]}"></td>
+                <td th:text="${dp.value[4]}"></td>
+                <td th:text="${dp.value[3]}"></td>
+                <td th:text="${dp.value[2]}"></td>
+                <td th:text="${dp.value[1]}"></td>
+                <td th:text="${dp.value[0]}"></td>
+              </tr>
             </tbody>
-        </table>
+          </table>
+        </div>
+      </div>
+    </div>
+    <br /><br />
 
+    <div class="container" th:if="${quarantinedComponentsData}">
+      <div class="row">
+        <div class="col-xl mx-auto w-auto bg-white rounded">
+            <h5>Quarantined Components Report</h5>
+            <table class="table table-striped table-bordered table-sm">
+              <caption>
+                The list of quarantined components
+              </caption>
+              <thead class="tablecolumncolor">
+                <tr>
+                  <th class="th-sm">Repository</th>
+                  <th class="th-sm">Quarantine Date</th>
+                  <th class="th-sm">Date Cleared</th>
+                  <th class="th-sm">Package Name</th>
+                  <th class="th-sm">Format</th>
+                  <th class="th-sm">Quarantined</th>
+                  <th class="th-sm">Policy Name</th>
+                  <th class="th-sm">Threat Level</th>
+                  <th class="th-sm">Reason</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr th:each="dp : ${quarantinedComponents}">
+                  <td th:text="${dp.repository}"></td>
+                  <td th:text="${dp.quarantineDate}"></td>
+                  <td th:text="${dp.dateCleared} ?: 'N/A'"></td>
+                  <td th:text="${dp.displayName}"></td>
+                  <td th:text="${dp.format}"></td>
+                  <td th:text="${dp.quarantined}"></td>
+                  <td th:text="${dp.policyName}"></td>
+                  <td th:text="${dp.threatLevel}"></td>
+                  <td th:text="${dp.reason}"></td>
+                </tr>
+              </tbody>
+            </table>
         </div>
-        </div>
-        </div>
-        </div>
+      </div>
+    </div>
 
+    <div class="container" th:if="${autoReleasedFromQuarantinedComponentsData}">
+      <div class="row">
+        <div class="col-xl mx-auto w-auto bg-white rounded">
+          <div class="table-responsive table-wrapper-scroll-y custom-scrollbar">
+            <h5>Autoreleased from Quarantined Components Report</h5>
 
-    </body>
+            <table class="table table-striped table-bordered table-sm">
+              <caption>
+                The list of components which have been autoreleased from quarantine
+              </caption>
+              <thead class="tablecolumncolor">
+                <tr>
+                  <th class="th-sm">Repository</th>
+                  <th class="th-sm">Quarantine Date</th>
+                  <th class="th-sm">Date Cleared</th>
+                  <th class="th-sm">Package Name</th>
+                  <th class="th-sm">Format</th>
+                  <th class="th-sm">Quarantined</th>
+                  <th class="th-sm">Policy Name</th>
+                  <th class="th-sm">Threat Level</th>
+                  <th class="th-sm">Reason</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr th:each="dp : ${autoReleasedFromQuarantinedComponents}">
+                  <td th:text="${dp.repository}"></td>
+                  <td th:text="${dp.quarantineDate}"></td>
+                  <td th:text="${dp.dateCleared}"></td>
+                  <td th:text="${dp.displayName}"></td>
+                  <td th:text="${dp.format}"></td>
+                  <td th:text="${dp.quarantined}"></td>
+                  <td th:text="${dp.policyName}"></td>
+                  <td th:text="${dp.threatLevel}"></td>
+                  <td th:text="${dp.reason}"></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
 </html>

--- a/view-metrics/src/test/java/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.java
+++ b/view-metrics/src/test/java/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.java
@@ -98,7 +98,7 @@ public class SuccessMetricsWebApplicationTest {
                 "applications.html, 23",
                 "securityviolations.html, 23",
                 "licenseviolations.html, 23",
-                "firewall.html, 24",
+                "firewall.html, 23",
                 "violationsage.html?date=2022-03-01, 24",
                 "evaluations.html?date=2021-11-01, 23",
                 "analysis.html, 23",

--- a/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.firewall.html.approved.txt
+++ b/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.firewall.html.approved.txt
@@ -1,9 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-<html>
-
-<head>
-<div><div>
+  <head>
+    <title>Firewall report</title>
+    <div><div>
 
     <meta charset="utf-8"/>
     <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
@@ -146,212 +145,304 @@
     </script>
 
 </div></div>
-</head>
+  </head>
 
-   <body>
+  <body>
+    <div class="jumbotron">
+      <h4>Firewall Report</h4>
+    </div>
 
-        <div class="jumbotron">
-        <h4>Firewall Report</h4>
-        </div>
-
-        <div class="container">
-        <div class="row">
+    <div class="container">
+      <div class="row">
         <div class="col-xl mx-auto w-auto bg-white rounded">
+          <h5>Quarantined Components Summary Report</h5>
 
-        <h5>Quarantined Components Summary Report</h5>
-
-        <table class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
-        <thead class="tablecolumncolor">
-            <tr>
+          <table class="table table-striped table-bordered table-sm">
+            <caption>
+              Summary information about Firewall usage
+            </caption>
+            <thead class="tablecolumncolor">
+              <tr>
                 <th class="th-sm">Repository Count</th>
                 <th class="th-sm">Quarantine Enabled RepositoryCount</th>
                 <th class="th-sm">Quarantine Enabled</th>
                 <th class="th-sm">Total Component Count</th>
                 <th class="th-sm">Quarantined Component Count</th>
-            </tr>
+              </tr>
             </thead>
             <tbody>
-            <tr>
+              <tr>
                 <td>8</td>
                 <td>4</td>
                 <td>true</td>
                 <td>94</td>
                 <td>23</td>
-            </tr>
+              </tr>
             </tbody>
-        </table>
+          </table>
+        </div>
+      </div>
+    </div>
+    <br /><br />
 
-        </div>
-        </div>
-        </div>
-        </div>
-
-        <br><br>
-
-        <div class="container">
-        <div class="row">
+    <div class="container">
+      <div class="row">
         <div class="col-xl mx-auto w-auto bg-white rounded">
+          <h5>Autoreleased Quarantined Components Summary Report</h5>
 
-        <h5>Autoreleased Quarantined Components Summary Report</h5>
-
-        <table class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
-        <thead class="tablecolumncolor">
-            <tr>
+          <table class="table table-striped table-bordered table-sm">
+            <caption>
+              Summary of autoreleased components
+            </caption>
+            <thead class="tablecolumncolor">
+              <tr>
                 <th class="th-sm">AutoRelease Quarantine Count (MTD)</th>
                 <th class="th-sm">AutoRelease Quarantine Count (YTD)</th>
-            </tr>
+              </tr>
             </thead>
             <tbody>
-            <tr>
+              <tr>
                 <td>2</td>
                 <td>2</td>
-            </tr>
+              </tr>
             </tbody>
-        </table>
+          </table>
+        </div>
+      </div>
+    </div>
+    <br /><br />
 
-        </div>
-        </div>
-        </div>
-        </div>
-
-        <br><br>
-
-        <div class="container">
-        <div class="row">
+    <div class="container">
+      <div class="row">
         <div class="col-xl mx-auto w-auto bg-white rounded">
-        <div class="table-responsive table-wrapper-scroll-y custom-scrollbar">
+          <h5>Quarantined Threat Level By Format</h5>
 
-        <h5>Quarantined Components Report</h5>
-
-        <table class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
-        <thead class="tablecolumncolor">
-            <tr>
-                <th class="th-sm">Repository</th>
-                <th class="th-sm">Quarantine Date</th>
-                <th class="th-sm">Date Cleared</th>
-                <th class="th-sm">Package Name</th>
+          <table class="table table-striped table-bordered table-sm">
+            <caption>
+              The number of quarantined violations by threat level sorted by format of the package with the violation.
+            </caption>
+            <thead class="tablecolumncolor">
+              <tr>
                 <th class="th-sm">Format</th>
-                <th class="th-sm">Quarantined</th>
-                <th class="th-sm">Policy Name</th>
-                <th class="th-sm">Threat Level</th>
-                <th class="th-sm">Reason</th>
-
-            </tr>
+                <th class="th-sm">Threat 10</th>
+                <th class="th-sm">Threat 9</th>
+                <th class="th-sm">Threat 8</th>
+                <th class="th-sm">Threat 7</th>
+                <th class="th-sm">Threat 6</th>
+                <th class="th-sm">Threat 5</th>
+                <th class="th-sm">Threat 4</th>
+                <th class="th-sm">Threat 3</th>
+                <th class="th-sm">Threat 2</th>
+                <th class="th-sm">Threat 1</th>
+                <th class="th-sm">Threat 0</th>
+              </tr>
             </thead>
             <tbody>
-            <tr>
-                <td>maven-central-fw</td>
-                <td>2021-10-13 11:11:43.5</td>
-                <td>N/A</td>
-                <td>com.sonatype.clm:clm-maven-plugin:2.19.0-01</td>
+              <tr>
                 <td>maven</td>
-                <td>true</td>
-                <td>License-Not-Provided</td>
-                <td>9</td>
-                <td></td>
-
-            </tr>
-            <tr>
-                <td>maven-central-fw</td>
-                <td>2021-10-13 11:11:43.5</td>
-                <td>N/A</td>
-                <td>com.sonatype.clm:clm-maven-plugin:2.19.0-01</td>
-                <td>maven</td>
-                <td>true</td>
-                <td>License-Banned</td>
-                <td>10</td>
-                <td>Proprietary-Clause</td>
-
-            </tr>
-            <tr>
-                <td>maven-central-fw</td>
-                <td>2021-10-13 11:11:46.325</td>
-                <td>N/A</td>
-                <td>com.sonatype.clm:clm-maven-plugin:2.18.0-01</td>
-                <td>maven</td>
-                <td>true</td>
-                <td>License-Not-Provided</td>
-                <td>9</td>
-                <td></td>
-
-            </tr>
-            <tr>
-                <td>maven-central-fw</td>
-                <td>2021-10-13 11:11:46.325</td>
-                <td>N/A</td>
-                <td>com.sonatype.clm:clm-maven-plugin:2.18.0-01</td>
-                <td>maven</td>
-                <td>true</td>
-                <td>License-Banned</td>
-                <td>10</td>
-                <td>Proprietary-Clause</td>
-
-            </tr>
-            <tr>
-                <td>maven-central-fw</td>
-                <td>2021-11-18 17:40:38.953</td>
-                <td>N/A</td>
-                <td>org.apache.maven.plugins:maven-jar-plugin:2.4</td>
-                <td>maven</td>
-                <td>true</td>
-                <td>License-Banned</td>
-                <td>10</td>
-                <td>Apache-2.0</td>
-
-            </tr>
+                <td>3</td>
+                <td>2</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+              </tr>
             </tbody>
-        </table>
+          </table>
+        </div>
+      </div>
+    </div>
+    <br /><br />
 
-        </div>
-        </div>
-        </div>
-        </div>
-
-        <br><br>
-
-        <div class="container">
-        <div class="row">
+    <div class="container">
+      <div class="row">
         <div class="col-xl mx-auto w-auto bg-white rounded">
-        <div class="table-responsive table-wrapper-scroll-y custom-scrollbar">
+          <h5>Quarantined Threat Level By Month Raised</h5>
 
-        <h5>Autoreleased from Quarantined Components Report</h5>
-
-        <table class="table table-striped table-bordered table-sm" cellspacing="0" width="100%">
-        <thead class="tablecolumncolor">
-            <tr>
-                <th class="th-sm">Repository</th>
-                <th class="th-sm">Quarantine Date</th>
-                <th class="th-sm">Date Cleared</th>
-                <th class="th-sm">Package Name</th>
-                <th class="th-sm">Format</th>
-                <th class="th-sm">Quarantined</th>
-                <th class="th-sm">Policy Name</th>
-                <th class="th-sm">Threat Level</th>
-                <th class="th-sm">Reason</th>
-
-            </tr>
+          <table class="table table-striped table-bordered table-sm">
+            <caption>
+              The number of quarantined violations by threat level sorted by month the packages was put in quarantine.
+            </caption>
+            <thead class="tablecolumncolor">
+              <tr>
+                <th class="th-sm">Month</th>
+                <th class="th-sm">Threat 10</th>
+                <th class="th-sm">Threat 9</th>
+                <th class="th-sm">Threat 8</th>
+                <th class="th-sm">Threat 7</th>
+                <th class="th-sm">Threat 6</th>
+                <th class="th-sm">Threat 5</th>
+                <th class="th-sm">Threat 4</th>
+                <th class="th-sm">Threat 3</th>
+                <th class="th-sm">Threat 2</th>
+                <th class="th-sm">Threat 1</th>
+                <th class="th-sm">Threat 0</th>
+              </tr>
             </thead>
             <tbody>
-            <tr>
-                <td>test_repo</td>
-                <td>2021-10-13 11:11:43.5</td>
-                <td>2021-10-13 11:11:43.5</td>
-                <td>test_display</td>
-                <td>test_format</td>
-                <td>true</td>
-                <td>test_policy</td>
-                <td>10</td>
-                <td>test_reason</td>
-
-            </tr>
+              <tr>
+                <td>2021-11</td>
+                <td>1</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+              </tr>
+              <tr>
+                <td>2021-10</td>
+                <td>2</td>
+                <td>2</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+                <td>0</td>
+              </tr>
             </tbody>
-        </table>
+          </table>
+        </div>
+      </div>
+    </div>
+    <br /><br />
 
+    <div class="container">
+      <div class="row">
+        <div class="col-xl mx-auto w-auto bg-white rounded">
+            <h5>Quarantined Components Report</h5>
+            <table class="table table-striped table-bordered table-sm">
+              <caption>
+                The list of quarantined components
+              </caption>
+              <thead class="tablecolumncolor">
+                <tr>
+                  <th class="th-sm">Repository</th>
+                  <th class="th-sm">Quarantine Date</th>
+                  <th class="th-sm">Date Cleared</th>
+                  <th class="th-sm">Package Name</th>
+                  <th class="th-sm">Format</th>
+                  <th class="th-sm">Quarantined</th>
+                  <th class="th-sm">Policy Name</th>
+                  <th class="th-sm">Threat Level</th>
+                  <th class="th-sm">Reason</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>maven-central-fw</td>
+                  <td>2021-10-13T11:11:43.500</td>
+                  <td>N/A</td>
+                  <td>com.sonatype.clm:clm-maven-plugin:2.19.0-01</td>
+                  <td>maven</td>
+                  <td>true</td>
+                  <td>License-Not-Provided</td>
+                  <td>9</td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>maven-central-fw</td>
+                  <td>2021-10-13T11:11:43.500</td>
+                  <td>N/A</td>
+                  <td>com.sonatype.clm:clm-maven-plugin:2.19.0-01</td>
+                  <td>maven</td>
+                  <td>true</td>
+                  <td>License-Banned</td>
+                  <td>10</td>
+                  <td>Proprietary-Clause</td>
+                </tr>
+                <tr>
+                  <td>maven-central-fw</td>
+                  <td>2021-10-13T11:11:46.325</td>
+                  <td>N/A</td>
+                  <td>com.sonatype.clm:clm-maven-plugin:2.18.0-01</td>
+                  <td>maven</td>
+                  <td>true</td>
+                  <td>License-Not-Provided</td>
+                  <td>9</td>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td>maven-central-fw</td>
+                  <td>2021-10-13T11:11:46.325</td>
+                  <td>N/A</td>
+                  <td>com.sonatype.clm:clm-maven-plugin:2.18.0-01</td>
+                  <td>maven</td>
+                  <td>true</td>
+                  <td>License-Banned</td>
+                  <td>10</td>
+                  <td>Proprietary-Clause</td>
+                </tr>
+                <tr>
+                  <td>maven-central-fw</td>
+                  <td>2021-11-18T17:40:38.953</td>
+                  <td>N/A</td>
+                  <td>org.apache.maven.plugins:maven-jar-plugin:2.4</td>
+                  <td>maven</td>
+                  <td>true</td>
+                  <td>License-Banned</td>
+                  <td>10</td>
+                  <td>Apache-2.0</td>
+                </tr>
+              </tbody>
+            </table>
         </div>
-        </div>
-        </div>
-        </div>
+      </div>
+    </div>
 
+    <div class="container">
+      <div class="row">
+        <div class="col-xl mx-auto w-auto bg-white rounded">
+          <div class="table-responsive table-wrapper-scroll-y custom-scrollbar">
+            <h5>Autoreleased from Quarantined Components Report</h5>
 
-    </body>
+            <table class="table table-striped table-bordered table-sm">
+              <caption>
+                The list of components which have been autoreleased from quarantine
+              </caption>
+              <thead class="tablecolumncolor">
+                <tr>
+                  <th class="th-sm">Repository</th>
+                  <th class="th-sm">Quarantine Date</th>
+                  <th class="th-sm">Date Cleared</th>
+                  <th class="th-sm">Package Name</th>
+                  <th class="th-sm">Format</th>
+                  <th class="th-sm">Quarantined</th>
+                  <th class="th-sm">Policy Name</th>
+                  <th class="th-sm">Threat Level</th>
+                  <th class="th-sm">Reason</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>test_repo</td>
+                  <td>2021-10-13T11:11:43.500</td>
+                  <td>2021-10-13T11:11:43.500</td>
+                  <td>test_display</td>
+                  <td>test_format</td>
+                  <td>true</td>
+                  <td>test_policy</td>
+                  <td>10</td>
+                  <td>test_reason</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
This PR adds two new tables to the Firewall report:
1. threats are quarantined by format (for example "pypi" or "npm") vs threat level.
2. the number of applications quarantined by threat level by month