### PR TITLE
Fixed fault in license waiver handling

### DIFF
--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/reports/PolicyViolations.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/reports/PolicyViolations.java
@@ -123,11 +123,12 @@ public class PolicyViolations implements CsvFileService {
 
             Pattern pattern = Pattern.compile("^.+\'(.+)\'");
             Matcher matcher = pattern.matcher(licenseFound);
-            matcher.find();
-            String license = matcher.group(1);
+            if (matcher.find()) {
+                licenseFound = matcher.group(1);
+            }
 
-            if (!licenses.contains(license)) {
-                licenses.add(license);
+            if (!licenses.contains(licenseFound)) {
+                licenses.add(licenseFound);
             }
         }
 

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/reports/PolicyViolationsTest.java
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/reports/PolicyViolationsTest.java
@@ -83,12 +83,21 @@ public class PolicyViolationsTest {
                 "build",
                 "10"
             };
-            // TODO integrity test is currently not in the input JSON
+            String[] row3 = {
+                "License-None",
+                "Non-license string for testing",
+                "WebGoat",
+                "2022-02-15T10:11:04.055+0000",
+                "\"pkg:maven/org.projectlombok/lombok@1.18.20?type=jar\"",
+                "build",
+                "7"
+            };
 
-            Assertions.assertEquals(3, policyViolations.size());
+            Assertions.assertEquals(4, policyViolations.size());
             Assertions.assertArrayEquals(header, policyViolations.get(0));
             Assertions.assertArrayEquals(row1, policyViolations.get(1));
             Assertions.assertArrayEquals(row2, policyViolations.get(2));
+            Assertions.assertArrayEquals(row3, policyViolations.get(3));
 
         } catch (FileNotFoundException e) {
             Assertions.fail();

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/resources/policyViolations.json
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/resources/policyViolations.json
@@ -87,6 +87,44 @@
                         "displayName": "com.thoughtworks.xstream : xstream : 1.4.5",
                         "proprietary": false
                     }
+                },
+                {
+                    "policyId": "26c36821604541f8848a6ae6889956b7",
+                    "policyName": "License-None",
+                    "policyViolationId": "82db9ee5a007433795585a5793cc0aac",
+                    "threatLevel": 7,
+                    "constraintViolations": [
+                        {
+                            "constraintId": "eec97815c2784006a2ece5cb65ea271a",
+                            "constraintName": "MIT License",
+                            "reasons": [
+                                {
+                                    "reason": "Non-license string for testing",
+                                    "reference": null
+                                }
+                            ]
+                        }
+                    ],
+                    "stageId": "build",
+                    "reportId": "27840c6b986c451e8806e1d0b8ef2787",
+                    "reportUrl": "ui/links/application/WebGoat/report/27840c6b986c451e8806e1d0b8ef2787",
+                    "openTime": "2022-02-15T10:11:04.055+0000",
+                    "component": {
+                        "packageUrl": "pkg:maven/org.projectlombok/lombok@1.18.20?type=jar",
+                        "hash": "18bcea7d5df4d49227b4",
+                        "componentIdentifier": {
+                            "format": "maven",
+                            "coordinates": {
+                                "artifactId": "lombok",
+                                "classifier": "",
+                                "extension": "jar",
+                                "groupId": "org.projectlombok",
+                                "version": "1.18.20"
+                            }
+                        },
+                        "displayName": "org.projectlombok : lombok : 1.18.20",
+                        "proprietary": false
+                    }
                 }
            ]
         }


### PR DESCRIPTION
Before this PR fetching policy license violations with names "License-Banned", "License-None",
"License-Copyleft" and a reason not containing a license caused an IllegalStateException
error in PolicyViolations.java.

This PR removes that failure.
