### PR TITLE
Add warning of empty files fetched by get-metrics

### DIFF
--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/FileIoService.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/FileIoService.java
@@ -18,6 +18,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 @Service
 public class FileIoService {
@@ -65,5 +66,21 @@ public class FileIoService {
         java.nio.file.Files.copy(content, outputFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         IOUtils.closeQuietly(content);
         log.info("Created file: {}", outputFile.toPath());
+        Stream<String> stream = null;
+        try {
+            stream = java.nio.file.Files.lines(outputFile.toPath());
+            if (stream.count() <= 1) {
+                log.warn(
+                        "The file {} contains no data, either there is no data to fetch or the user"
+                                + " doesn't have the appropriate permissions to fetch it.",
+                        outputFile.toPath());
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            if (stream != null) {
+                stream.close();
+            }
+        }
     }
 }


### PR DESCRIPTION
Before this PR CSVs generated by get-metrics could contain only a header and this was not obvious until view-metrics was run. CSVs can be empty for a number of reasons for example:
1. A valid user doesn't have access to the organisation they are retrieving information from
2. There really is no data to fetch from the API.
... so it is not possible to call an empty file a failure.

This PR adds a warning in the CLI output to say that a file is empty, to prompt for further investigation and analysis if needed.
