### PR TITLE
Added stack trace in case of SSL failure to help troubleshooting

### DIFF
--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/GetMetricsApplication.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/GetMetricsApplication.java
@@ -110,6 +110,7 @@ public class GetMetricsApplication implements CommandLineRunner {
             log.info(
                     "To disable security certificate checking please specify"
                             + " '--insecure.ssl=true'");
+            throw (e);
         }
     }
 }


### PR DESCRIPTION
There are reports of --insecure.ssl not working, however before this PR there
is no information presented at an SSL failure to allow further analysis.

This PR introduces the printing of a stack trace in the case of an SSL failure.
