### PR TITLE
Added warning for not enough data for insights analysis

### DIFF
--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/service/LoaderService.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/service/LoaderService.java
@@ -146,6 +146,13 @@ public class LoaderService {
         Map<String, Object> periods =
                 periodsDataService.getPeriodData(SqlStatements.METRICTABLENAME);
 
+        if (periods == null || periods.isEmpty() || periods.get("midPeriod") == null) {
+            log.error(
+                    "Not enough periods were found in the successmetrics.csv data. At least three"
+                            + " full months or weeks of data are needed");
+            throw new IllegalStateException("");
+        }
+
         String midPeriod = periods.get("midPeriod").toString();
 
         log.info("Mid period: {}", midPeriod);


### PR DESCRIPTION
Before this PR the view-metrics script could fail without explanation if
there were insufficient periods in the successmetrics.csv file. In order
to run correctly insights analysis needs three complete periods (whether
days or months).

After this PR an error message is generated when insights analysis cannot
be generated with the aim of being clearer as to the cause when view-metrics
is run, rather than needing post-analysis.
