### PR TITLE
Change get-metrics to use month by default

### DIFF
--- a/get-metrics/application.properties
+++ b/get-metrics/application.properties
@@ -16,10 +16,10 @@ iq.user=admin
 iq.passwd=admin123
 
 # mandatory: week, month
-iq.api.sm.period=week
+iq.api.sm.period=month
 
 # mandatory: example: week=2020-W01, month=2020-01
-iq.api.sm.payload.timeperiod.first=2020-W01
+iq.api.sm.payload.timeperiod.first=2020-01
 
 # optional
 iq.api.sm.payload.timeperiod.last=


### PR DESCRIPTION
About 4 months ago the time period application.properties for get-metrics was changed to weekly rather than monthly by mistake. This PR changes is back to month.