### PR TITLE
Fixed failing tests

### DIFF
--- a/view-metrics/build.gradle
+++ b/view-metrics/build.gradle
@@ -35,3 +35,7 @@ dependencies {
 	testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
 	testImplementation("com.approvaltests:approvaltests:12.4.1")
 }
+
+test {
+	forkEvery = 1
+}


### PR DESCRIPTION
Before this tests view-metrics PRs were failing. This seems to be due to some
interaction between the various test suites. After this PR view-metrics tests
will not run in parallel, this means that testing will take longer however
tests will actually pass.
