### PR TITLE
Added ability to specify address for viewing view-metrics

### DIFF
--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/SuccessMetricsApplication.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/SuccessMetricsApplication.java
@@ -34,6 +34,7 @@ public class SuccessMetricsApplication implements CommandLineRunner {
     private String activeProfile;
     private String pdfTemplate;
     private String port;
+    private String server_address;
     private String contextPath;
 
     private boolean doAnalysis = true;
@@ -49,6 +50,7 @@ public class SuccessMetricsApplication implements CommandLineRunner {
             @Value("${spring.profiles.active}") String activeProfile,
             @Value("${pdf.htmltemplate}") String pdfTemplate,
             @Value("${server.port}") String port,
+            @Value("${server.address:localhost}") String server_address,
             @Value("${server.servlet.context-path:}") String contextPath) {
         this.loaderService = loaderService;
         this.pdfService = pdfService;
@@ -58,6 +60,7 @@ public class SuccessMetricsApplication implements CommandLineRunner {
         this.activeProfile = activeProfile;
         this.pdfTemplate = pdfTemplate;
         this.port = port;
+        this.server_address = server_address;
         this.contextPath = contextPath;
     }
 
@@ -102,7 +105,8 @@ public class SuccessMetricsApplication implements CommandLineRunner {
 
     private void startUp() {
         log.info(
-                "Ready for viewing at http://localhost:{}{}",
+                "Ready for viewing at http://{}:{}{}",
+                server_address,
                 port,
                 contextPath != null ? contextPath : "");
     }


### PR DESCRIPTION
We received a request to be able to specify the IP address that the
view-metrics (Tomcat) server uses, rather than the hardcoded value
of "localhost". After this PR it is possible to specify this address
by setting `server.address` in the view-metrics `application.properties`
file. The default remains as "localhost".

It should be noted that the use of view-metrics web server as a
permanently running service is not the intended use case. The web-server
has not been designed and configured to operate in this way. So while
this change has been implemented it is used at your own risk.

