### PR TITLE
Fix the backlog rate calculation in data-extract csv

### DIFF
--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/service/DataExtractService.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/service/DataExtractService.java
@@ -306,7 +306,7 @@ public class DataExtractService {
     }
 
     private int calculateBacklogRate(int discovered, int fixed) {
-        return Math.round(((float) discovered / fixed) * 100);
+        return Math.round(((float) fixed / discovered) * 100);
     }
 
     private float calculateDiscoveryRate(int applications, int discovered) {


### PR DESCRIPTION
The backlog rate calculation needs inverting as it should be 'fixed violations / discovered violations'.
Only the calculation has been modified.