### PR TITLE
Add a note about comma-separated list for org/app in get-metrics

### DIFF
--- a/get-metrics/application.properties
+++ b/get-metrics/application.properties
@@ -27,6 +27,9 @@ iq.api.sm.payload.timeperiod.last=
 # optional: set one of the two below to a comma-separated list
 # if both omitted (the default), all organisations/applications will apply
 # if both set, organisation will take precedence
+# NOTE: there should not be spaces between the commas in the comma-separated list
+#       Good Example: iq.api.sm.payload.organisation.name=org1,org2
+#       Bad Example:  iq.api.sm.payload.organisation.name=org1, org2
 iq.api.sm.payload.organisation.name=
 iq.api.sm.payload.application.name=
 

--- a/get-metrics/application.properties
+++ b/get-metrics/application.properties
@@ -16,10 +16,10 @@ iq.user=admin
 iq.passwd=admin123
 
 # mandatory: week, month
-iq.api.sm.period=week
+iq.api.sm.period=month
 
 # mandatory: example: week=2020-W01, month=2020-01
-iq.api.sm.payload.timeperiod.first=2020-W01
+iq.api.sm.payload.timeperiod.first=2020-01
 
 # optional
 iq.api.sm.payload.timeperiod.last=

--- a/get-metrics/src/main/resources/application.properties
+++ b/get-metrics/src/main/resources/application.properties
@@ -27,6 +27,9 @@ iq.api.sm.payload.timeperiod.last=
 # optional: set one of the two below to a comma-separated list
 # if both omitted (the default), all organisations/applications will apply
 # if both set, organisation will take precedence
+# NOTE: there should not be spaces between the commas in the comma-separated list
+#       Good Example: iq.api.sm.payload.organisation.name=org1,org2
+#       Bad Example:  iq.api.sm.payload.organisation.name=org1, org2
 iq.api.sm.payload.organisation.name=
 iq.api.sm.payload.application.name=
 

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/SuccessMetricsApplication.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/SuccessMetricsApplication.java
@@ -34,6 +34,7 @@ public class SuccessMetricsApplication implements CommandLineRunner {
     private String activeProfile;
     private String pdfTemplate;
     private String port;
+    private String server_address;
     private String contextPath;
 
     private boolean doAnalysis = true;
@@ -49,6 +50,7 @@ public class SuccessMetricsApplication implements CommandLineRunner {
             @Value("${spring.profiles.active}") String activeProfile,
             @Value("${pdf.htmltemplate}") String pdfTemplate,
             @Value("${server.port}") String port,
+            @Value("${server.address:localhost}") String server_address,
             @Value("${server.servlet.context-path:}") String contextPath) {
         this.loaderService = loaderService;
         this.pdfService = pdfService;
@@ -58,6 +60,7 @@ public class SuccessMetricsApplication implements CommandLineRunner {
         this.activeProfile = activeProfile;
         this.pdfTemplate = pdfTemplate;
         this.port = port;
+        this.server_address = server_address;
         this.contextPath = contextPath;
     }
 
@@ -102,7 +105,8 @@ public class SuccessMetricsApplication implements CommandLineRunner {
 
     private void startUp() {
         log.info(
-                "Ready for viewing at http://localhost:{}{}",
+                "Ready for viewing at http://{}:{}{}",
+                server_address,
                 port,
                 contextPath != null ? contextPath : "");
     }


### PR DESCRIPTION
This PR introduces examples into the get-metrics application.properties file showing
that the comma-separated list for iq.api.sm.payload.organisation.name and
iq.api.sm.payload.application.name should not include spaces
