### PR TITLE
Update insecure SSL handling

### DIFF
--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/util/InsecureSSL.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/util/InsecureSSL.java
@@ -15,6 +15,8 @@ import javax.net.ssl.X509TrustManager;
 
 public class InsecureSSL {
 
+    private static final X509Certificate[] NO_CERTIFICATES = {};
+
     private InsecureSSL() {}
 
     public static void makeSSLConnectionsInsecure()
@@ -25,7 +27,7 @@ public class InsecureSSL {
                 new TrustManager[] {
                     new X509TrustManager() {
                         public X509Certificate[] getAcceptedIssuers() {
-                            return new X509Certificate[0];
+                            return NO_CERTIFICATES;
                         }
 
                         @Override


### PR DESCRIPTION
Before this PR there are reports of get-metrics failing when insecure.ssl=true
and where the users' IQ instances have self-signed certificates. This PR attempts
to address that.

Since this scenarion is difficult to recreate, the only testing that has been
performed is "no harm" testing - i.e. get-metrics works with an IQ instance
with a valid certificate over HTTPS and with insecure.ssl=true. Testing of 
this PR will need to be confirmed in the field.
