### PR TITLE
Fixed waiver failure in get-metrics on null packageUrl

### DIFF
--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/reports/Waivers.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/reports/Waivers.java
@@ -71,7 +71,7 @@ public class Waivers implements CsvFileService {
                 for (JsonObject componentViolation :
                         componentViolations.getValuesAs(JsonObject.class)) {
                     JsonObject component = componentViolation.getJsonObject("component");
-                    String packageUrl = component.getString("packageUrl");
+                    String packageUrl = getFieldStringFromJsonObject(component, "packageUrl");
                     JsonArray waivedPolicyViolations =
                             componentViolation.getJsonArray("waivedPolicyViolations");
 
@@ -111,6 +111,6 @@ public class Waivers implements CsvFileService {
         if (policyWaiver.get(field) == null) {
             return "";
         }
-        return String.valueOf(policyWaiver.get(field));
+        return String.valueOf(policyWaiver.getString(field));
     }
 }

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/reports/WaiversTest.java
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/reports/WaiversTest.java
@@ -33,10 +33,10 @@ public class WaiversTest {
                         "pkg:pypi/flask@2.0.2?extension=tar.gz",
                         "Security-Medium",
                         "7",
-                        "\"This has been mitigated in"
-                                + " https://github.com/example/application/pull/5\"",
-                        "\"2022-01-25T10:55:55.444+0000\"",
-                        "\"2022-01-26T10:55:55.444+0000\""
+                        "This has been mitigated in"
+                                + " https://github.com/example/application/pull/5",
+                        "2022-01-25T10:55:55.444+0000",
+                        "2022-01-26T10:55:55.444+0000"
                     },
                     data.get(0));
             Assertions.assertArrayEquals(
@@ -46,9 +46,9 @@ public class WaiversTest {
                         "pkg:pypi/flask@2.0.2?extension=tar.gz",
                         "Security-Medium",
                         "7",
-                        "\"This has been mitigated in"
-                                + " https://github.com/example/application/pull/5\"",
-                        "\"2022-01-25T10:55:55.444+0000\"",
+                        "This has been mitigated in"
+                                + " https://github.com/example/application/pull/5",
+                        "2022-01-25T10:55:55.444+0000",
                         ""
                     },
                     data.get(1));
@@ -112,10 +112,10 @@ public class WaiversTest {
                         "pkg:pypi/flask@2.0.2?extension=tar.gz",
                         "Security-Medium",
                         "7",
-                        "\"This has been mitigated in"
-                                + " https://github.com/example/application/pull/5\"",
-                        "\"2022-01-25T10:55:55.444+0000\"",
-                        "\"2022-01-26T10:55:55.444+0000\""
+                        "This has been mitigated in"
+                                + " https://github.com/example/application/pull/5",
+                        "2022-01-25T10:55:55.444+0000",
+                        "2022-01-26T10:55:55.444+0000"
                     },
                     data.get(1));
             Assertions.assertArrayEquals(
@@ -125,9 +125,9 @@ public class WaiversTest {
                         "pkg:pypi/flask@2.0.2?extension=tar.gz",
                         "Security-Medium",
                         "7",
-                        "\"This has been mitigated in"
-                                + " https://github.com/example/application/pull/5\"",
-                        "\"2022-01-25T10:55:55.444+0000\"",
+                        "This has been mitigated in"
+                                + " https://github.com/example/application/pull/5",
+                        "2022-01-25T10:55:55.444+0000",
                         ""
                     },
                     data.get(2));


### PR DESCRIPTION
Before this PR fetching waiver information using get-metrics fails
if the component packageUrl is "null".

After this PR this case passes with the packageUrl being set to an
empty string.
