### PR TITLE
Fixing issue with failing get-metrics waivers

### DIFF
--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/reports/Waivers.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/reports/Waivers.java
@@ -13,6 +13,9 @@ import java.util.List;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
+import javax.json.JsonString;
+import javax.json.JsonStructure;
+import javax.json.JsonValue;
 
 public class Waivers implements CsvFileService {
     private static final Logger log = LoggerFactory.getLogger(Waivers.class);
@@ -108,9 +111,24 @@ public class Waivers implements CsvFileService {
     }
 
     private static String getFieldStringFromJsonObject(JsonObject policyWaiver, String field) {
-        if (policyWaiver.get(field) == null) {
-            return "";
+        String result = "";
+        if (log.isDebugEnabled()) {
+            log.debug("getFieldStringFromJsonObject called for " + field);
         }
-        return String.valueOf(policyWaiver.getString(field));
+        if (policyWaiver.get(field) != null) {
+            JsonValue value = policyWaiver.get(field);
+            if (value instanceof JsonString) {
+                result = ((JsonString) value).getString();
+            } else if (value instanceof JsonStructure) {
+                // this happens when override key is present without a value
+                result = "";
+            } else {
+                result = value.toString();
+            }
+        }
+        if (result.equals("{}")) {
+            result = "";
+        }
+        return result;
     }
 }

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/FileIoService.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/FileIoService.java
@@ -1,5 +1,7 @@
 package org.sonatype.cs.getmetrics.service;
 
+import com.opencsv.CSVWriter;
+
 import org.apache.tomcat.util.http.fileupload.FileUtils;
 import org.apache.tomcat.util.http.fileupload.IOUtils;
 import org.slf4j.Logger;
@@ -16,7 +18,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -35,10 +36,10 @@ public class FileIoService {
         String metricsFile = metricsDir + "/" + filename;
 
         try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(metricsFile))) {
-            for (String[] array : data) {
-                writer.write(String.join(",", Arrays.asList(array)));
-                writer.newLine();
-            }
+            CSVWriter csvWriter = new CSVWriter(writer);
+            csvWriter.writeAll(data);
+            csvWriter.flush();
+            csvWriter.close();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/service/FileIoService.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/service/FileIoService.java
@@ -114,10 +114,6 @@ public class FileIoService {
         IOUtils.closeQuietly(content);
     }
 
-    public static List<String> fileToStringList(String filename) throws IOException {
-        return Files.readAllLines(Paths.get(filename));
-    }
-
     public void writeDataExtractCsvFile(String csvFilename, List<DataExtractObject> deoList) {
 
         try {

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/util/DataLoaderParams.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/util/DataLoaderParams.java
@@ -10,15 +10,15 @@ public class DataLoaderParams {
     public static final String SMHEADER = "applicationId,applicationName,applicationPublicId,";
 
     public static final String AEDATAFILE = "application_evaluations.csv";
-    public static final String AEFILEHEADER = "applicationName,evaluationDate,stage";
+    public static final String AEFILEHEADER = "\"applicationName\",\"evaluationDate\",\"stage\"";
 
     public static final String CWDATAFILE = "waivers.csv";
     public static final String CWFILEHEADER =
-            "applicationName,stage,packageUrl,policyName,threatLevel,comment,createDate,expiryTime";
+            "\"applicationName\",\"stage\",\"packageUrl\",\"policyName\",\"threatLevel\",\"comment\",\"createDate\",\"expiryTime\"";
 
     public static final String PVDATAFILE = "policy_violations.csv";
     public static final String PVFILEHEADER =
-            "policyName,reason,applicationName,openTime,component,stage,threatLevel";
+            "\"policyName\",\"reason\",\"applicationName\",\"openTime\",\"component\",\"stage\",\"threatLevel\"";
 
     public static final String QCDATAFILE = "quarantined_components.csv";
 

--- a/view-metrics/src/test/java/org/sonatype/cs/metrics/service/TestFileIoServiceTestShould.java
+++ b/view-metrics/src/test/java/org/sonatype/cs/metrics/service/TestFileIoServiceTestShould.java
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 @DisplayName("The fileIO service should")
 public class TestFileIoServiceTestShould {
@@ -46,29 +44,6 @@ public class TestFileIoServiceTestShould {
                 IOException.class,
                 () -> {
                     FileIoService.readJsonAsString("unknown file");
-                });
-    }
-
-    @DisplayName("return a list of strings with the contents of a file")
-    @Test
-    void testfileToStringListfileToStringList() {
-        List<String> expectedResult = new ArrayList<String>();
-        expectedResult.add("{\"Title\": \"This is a title\"}");
-        try {
-            Assertions.assertEquals(
-                    expectedResult, FileIoService.fileToStringList("src/test/resources/test.json"));
-        } catch (Exception e) {
-            Assertions.fail();
-        }
-    }
-
-    @DisplayName("throw an IOException if the requested file to convert to a list is empty")
-    @Test
-    void testfileToStringListfileToStringListFailure() {
-        Assertions.assertThrows(
-                IOException.class,
-                () -> {
-                    FileIoService.fileToStringList("unknown file");
                 });
     }
 }

--- a/view-metrics/src/test/resources/iqmetrics/application_evaluations.csv
+++ b/view-metrics/src/test/resources/iqmetrics/application_evaluations.csv
@@ -1,4 +1,4 @@
-applicationName,evaluationDate,stage
+"applicationName","evaluationDate","stage"
 TradingApp,2021-10-05T00:11:58.057+01:00,build
 Successmetrics,2021-10-05T00:10:54.301+01:00,build
 SecretSauce,2021-10-05T00:09:51.617+01:00,build

--- a/view-metrics/src/test/resources/iqmetrics/policy_violations.csv
+++ b/view-metrics/src/test/resources/iqmetrics/policy_violations.csv
@@ -1,4 +1,4 @@
-policyName,reason,applicationName,openTime,component,stage,threatLevel
+"policyName","reason","applicationName","openTime","component","stage","threatLevel"
 Security-Medium,CVE-2021-22060,nexusiq-successmetrics__sonatype-nexus-community,2022-01-28T13:45:32.492+0000,"pkg:maven/org.springframework/spring-webflux@5.3.12?type=jar",develop,7
 Security-Medium,CVE-2018-14335,nexusiq-successmetrics__sonatype-nexus-community,2022-01-28T13:45:32.492+0000,"pkg:maven/com.h2database/h2@2.0.202?type=jar",develop,7
 Security-Medium,sonatype-2021-1446,nexusiq-successmetrics__sonatype-nexus-community,2022-01-28T13:45:32.492+0000,"pkg:maven/ch.qos.logback/logback-core@1.2.6?type=jar",develop,7

--- a/view-metrics/src/test/resources/iqmetrics/waivers.csv
+++ b/view-metrics/src/test/resources/iqmetrics/waivers.csv
@@ -1,4 +1,4 @@
-applicationName,stage,packageUrl,policyName,threatLevel,comment,createDate,expiryTime
+"applicationName","stage","packageUrl","policyName","threatLevel","comment","createDate","expiryTime"
 wbg11,source,pkg:maven/axis/axis@1.2?type=jar,Security-High,9,"","2022-01-27T09:49:12.863+0000","2022-02-26T23:59:59.999+0000"
 wbg20,source,pkg:maven/axis/axis@1.2?type=jar,Security-High,9,"","2022-01-27T09:49:12.863+0000","2022-02-26T23:59:59.999+0000"
 webg2,source,pkg:maven/axis/axis@1.2?type=jar,Security-High,9,"","2022-01-27T09:49:12.863+0000","2022-02-26T23:59:59.999+0000"


### PR DESCRIPTION
Before this PR some waivers were failing:

```bash
Caused by: java.lang.ClassCastException: class javax.json.JsonValue$1 cannot be cast to class javax.json.JsonString 
(javax.json.JsonValue$1 and javax.json.JsonString are in unnamed module of loader 
org.springframework.boot.loader.LaunchedURLClassLoader @4678c730)
	at org.glassfish.json.JsonObjectBuilderImpl$JsonObjectImpl.getJsonString(JsonObjectBuilderImpl.java:252) 
~[javax.json-1.1.jar!/:1.1]
```

After this PR, the error no longer happens.

In addition this PR improves CSV handling by using a standard library. Impacted tests are updated.

NOTE: Some files produced by Success Metrics before this change may not load after this change.
