### PR TITLE
Bump tomcat-coyote

### DIFF
--- a/get-metrics/build.gradle
+++ b/get-metrics/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 	implementation 'org.apache.tomcat:tomcat-util:9.0.16'
 	implementation 'org.glassfish:javax.json:1.1'
 
-	implementation 'org.apache.tomcat:tomcat-coyote:8.5.72'
+	implementation 'org.apache.tomcat:tomcat-coyote:9.0.67'
 
 	implementation 'org.apache.commons:commons-csv:1.5'
 	implementation 'com.opencsv:opencsv:5.2'


### PR DESCRIPTION
This PR bumps org.apache.tomcat:tomcat-coyote to version 9.0.67
