### PR TITLE
Fix Windows Docker command

### DIFF
--- a/get-metrics/releasefiles/runapp-docker.bat
+++ b/get-metrics/releasefiles/runapp-docker.bat
@@ -1,2 +1,2 @@
 @echo off
-docker run --rm -it -v %CD%/config:/config -v %CD%/../iqmetrics:/iqmetrics ghcr.io/sonatype-nexus-community/getmetrics:@APPVER@ %*
+docker run --rm -it -v %CD%/config:/config -v %CD%/../iqmetrics:/iqmetrics ghcr.io/sonatype-nexus-community/nexusiq-successmetrics-get-metrics:@APPVER@ %*


### PR DESCRIPTION
This PR fixes an error in the Windows get-metrics docker BAT file.
