### PR TITLE
Add check that dates are in the correct format

### DIFF
--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQSuccessMetrics.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/NexusIQSuccessMetrics.java
@@ -8,6 +8,7 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.cs.getmetrics.model.PayloadItem;
+import org.sonatype.cs.getmetrics.util.DateCheck;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -61,6 +62,22 @@ public class NexusIQSuccessMetrics {
     }
 
     public void createSuccessMetricsCsvFile() throws IOException, JSONException, HttpException {
+        try {
+            DateCheck.checkDateFormat(iqSmPeriod, iqApiFirstTimePeriod);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Please check iq.api.sm.period and iq.api.sm.payload.timeperiod.first", e);
+        }
+
+        try {
+            if (!iqApiLastTimePeriod.equals("")) {
+                DateCheck.checkDateFormat(iqSmPeriod, iqApiLastTimePeriod);
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Please check iq.api.sm.period and iq.api.sm.payload.timeperiod.last", e);
+        }
+
         String apiPayload = getPayload();
 
         String content =

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/util/DateCheck.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/util/DateCheck.java
@@ -1,0 +1,32 @@
+package org.sonatype.cs.getmetrics.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DateCheck {
+    public static boolean checkDateFormat(String period, String date) {
+        if (!period.toUpperCase().equals("MONTH") && !period.toUpperCase().equals("WEEK")) {
+            throw new IllegalArgumentException("The period must be either MONTH or WEEK");
+        }
+        if (period.toUpperCase().equals("MONTH")) {
+            Pattern pattern = Pattern.compile("^\\d{4}-\\d{2}$", Pattern.CASE_INSENSITIVE);
+            Matcher matcher = pattern.matcher(date);
+            if (matcher.find()) {
+                return true;
+            } else {
+                throw new IllegalArgumentException(
+                        "iq.api.sm.period is set to MONTH but the dates prodived are not in 2022-01"
+                                + " format. Perhaps there is a W in there for week format?");
+            }
+        }
+        Pattern pattern = Pattern.compile("^\\d{4}-W\\d{2}$", Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(date);
+        if (matcher.find()) {
+            return true;
+        } else {
+            throw new IllegalArgumentException(
+                    "iq.api.sm.period is set to WEEK but the dates prodived are not in 2022-W01"
+                            + " format. Perhaps you've missed out the W?");
+        }
+    }
+}

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/util/DateCheckTest.java
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/util/DateCheckTest.java
@@ -1,0 +1,27 @@
+package org.sonatype.cs.getmetrics.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DateCheckTest {
+    @Test
+    void testValidDates() {
+        Assertions.assertTrue(DateCheck.checkDateFormat("MONTH", "2022-01"));
+        Assertions.assertTrue(DateCheck.checkDateFormat("WEEK", "2022-W01"));
+        Assertions.assertTrue(DateCheck.checkDateFormat("month", "2022-01"));
+        Assertions.assertTrue(DateCheck.checkDateFormat("week", "2022-w01"));
+        Assertions.assertTrue(DateCheck.checkDateFormat("week", "2022-W01"));
+    }
+
+    @Test
+    void testInvalidDates() {
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> DateCheck.checkDateFormat("MONTH", "2022-W01"),
+                "Expected checkDateFormat() to throw, but it didn't");
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> DateCheck.checkDateFormat("WEEK", "2022-01"),
+                "Expected checkDateFormat() to throw, but it didn't");
+    }
+}


### PR DESCRIPTION
This PR is raised in response to #100, it adds some more useful information if
the get-metrics period isn't correct for the given start date or end date.
