### PR TITLE
Fix error with multiple Firewall requests

### DIFF
--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/FileIoService.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/service/FileIoService.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -35,8 +36,18 @@ public class FileIoService {
 
         String metricsFile = metricsDir + "/" + filename;
 
-        try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(metricsFile))) {
+        File f = new File(metricsFile);
+        Boolean first_time_writing_to_file = !(f.exists() && !f.isDirectory());
+
+        try (BufferedWriter writer =
+                Files.newBufferedWriter(
+                        Paths.get(metricsFile),
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.APPEND)) {
             CSVWriter csvWriter = new CSVWriter(writer);
+            if (!first_time_writing_to_file) {
+                data.remove(0);
+            }
             csvWriter.writeAll(data);
             csvWriter.flush();
             csvWriter.close();

--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/util/ParseReasons.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/util/ParseReasons.java
@@ -33,11 +33,13 @@ public class ParseReasons {
         List<String> cves = new ArrayList<>();
 
         for (JsonObject reason : reasons.getValuesAs(JsonObject.class)) {
-            JsonObject reference = reason.getJsonObject("reference");
-            String cve = reference.getString("value");
+            if (!reason.isNull("reference")) {
+                JsonObject reference = reason.getJsonObject("reference");
+                String cve = reference.getString("value");
 
-            if (!cves.contains(cve)) {
-                cves.add(cve);
+                if (!cves.contains(cve)) {
+                    cves.add(cve);
+                }
             }
         }
 


### PR DESCRIPTION
Before this PR there are two issues:
- When fetching Firewall/quarantine data multiple quarantined components resulted in multiple API requests. Each API request overwrote data from the 
previous requests.
- When no reason was given in quarantine data then the get-metrics script would fail

This PR addresses those issues
