### PR TITLE
Remove requirement for success metrics in web view

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,9 @@ There are two modes to the application.
 
 The view-metrics script processes metrics stored in the `./nexusiq` directory and presents them as detailed aggregated charts in a web view or in data files in the `./datafiles` directory.
 
-&#9888; There must be a `successmetrics.csv` in the `./iqmetrics` directory.
+&#9888; In order to aggregate and process success metrics a minimum of three data points (weeks or months) are needed.
 
-&#9888; In order to aggregate and process metrics a minimum of three data points (weeks or months) are needed.
-
-&#9888; Only fully completed months (or weeks) are included in the data extract.
+&#9888; Only fully completed months (or weeks) are included in the success metrics data extract.
 
 ### View-metrics configuration
 

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/SuccessMetricsApplication.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/SuccessMetricsApplication.java
@@ -18,6 +18,7 @@ import java.text.ParseException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Objects;
 
 @SpringBootApplication
 @EnableJpaRepositories
@@ -78,24 +79,19 @@ public class SuccessMetricsApplication implements CommandLineRunner {
 
         successMetricsFileLoaded = loaderService.loadAllMetrics(activeProfile);
 
-        if (isSuccessMetricsFileLoaded()) {
-            if (runMode.contains("SERVLET")) {
-                // web app
-                this.startUp();
-            } else {
-                // non-interactive mode
-                this.timestamp =
-                        DateTimeFormatter.ofPattern("ddMMyy_HHmm")
-                                .format(LocalDateTime.now(ZoneId.systemDefault()));
-                if ("data".equals(activeProfile)) {
-                    createDataFiles();
-                } else {
-                    log.error("unknown profile");
-                }
-            }
+        if (runMode.contains("SERVLET")) {
+            // web app
+            this.startUp();
         } else {
-            log.error("No data files found");
-            System.exit(-1);
+            // non-interactive mode
+            this.timestamp =
+                    DateTimeFormatter.ofPattern("ddMMyy_HHmm")
+                            .format(LocalDateTime.now(ZoneId.systemDefault()));
+            if (Objects.equals(activeProfile, "data")) {
+                createDataFiles();
+            } else {
+                log.error("unknown profile");
+            }
         }
     }
 

--- a/view-metrics/src/main/resources/templates/home.html
+++ b/view-metrics/src/main/resources/templates/home.html
@@ -12,33 +12,29 @@
     	<div class="text-center">
 
     	<div th:if="${successmetricsreport}">
-    	<a th:href="@{summary.html}">Summary Report <em>(anonymised)</em></a>
-        <br><br>
-        <a th:href="@{applications.html}">Applications Report</a>
-        <br><br>
-        <a th:href="@{securityviolations.html}">Security Violations Report</a>
-        <br><br>
-        <a th:href="@{licenseviolations.html}">License Violations Report</a>
-        <br><br>
-        <!--
-		<a th:href="@{analysis}">Insights Analysis Data</a>
-        <br><br>
-        </div>
-        -->
+			<a th:href="@{summary.html}">Summary Report <em>(anonymised)</em></a>
+			<br><br>
+			<a th:href="@{applications.html}">Applications Report</a>
+			<br><br>
+			<a th:href="@{securityviolations.html}">Security Violations Report</a>
+			<br><br>
+			<a th:href="@{licenseviolations.html}">License Violations Report</a>
+			<br><br>
+		</div>
 
 		<div th:if="${firewallreport}">
 		<a th:href="@{firewall.html}">Firewall Report</a>
 		<br><br>
 		</div>
 
-	    <div th:if="${policyViolationsreport}">
-	    <a th:href="@{violationsage.html}">Policy Violations Report</a>
-	    <br><br>
-	    </div>
+		<div th:if="${policyViolationsreport}">
+		<a th:href="@{violationsage.html}">Policy Violations Report</a>
+		<br><br>
+		</div>
 
-	    <div th:if="${applicationEvaluationsreport}">
-	    <a th:href="@{evaluations.html}">Application Evaluations Report</a>
-	    <br><br>
+		<div th:if="${applicationEvaluationsreport}">
+		<a th:href="@{evaluations.html}">Application Evaluations Report</a>
+		<br><br>
 		</div>
 
 		<div th:if="${componentWaiversReport}">
@@ -46,11 +42,10 @@
 		<br><br>
 		</div>
 
-	    <div th:if="${smdatabase}">
-	    <a th:href="@{/h2}">Database</a>
-	    </div>
+		<div th:if="${smdatabase}">
+		<a th:href="@{/h2}">Database</a>
+		</div>
 
-       </div>
     </div>
 
 </body>

--- a/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.home.approved.txt
+++ b/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.home.approved.txt
@@ -154,33 +154,29 @@
     	<div class="text-center">
 
     	<div>
-    	<a href="summary.html">Summary Report <em>(anonymised)</em></a>
-        <br><br>
-        <a href="applications.html">Applications Report</a>
-        <br><br>
-        <a href="securityviolations.html">Security Violations Report</a>
-        <br><br>
-        <a href="licenseviolations.html">License Violations Report</a>
-        <br><br>
-        <!--
-		<a th:href="@{analysis}">Insights Analysis Data</a>
-        <br><br>
-        </div>
-        -->
+			<a href="summary.html">Summary Report <em>(anonymised)</em></a>
+			<br><br>
+			<a href="applications.html">Applications Report</a>
+			<br><br>
+			<a href="securityviolations.html">Security Violations Report</a>
+			<br><br>
+			<a href="licenseviolations.html">License Violations Report</a>
+			<br><br>
+		</div>
 
 		<div>
 		<a href="firewall.html">Firewall Report</a>
 		<br><br>
 		</div>
 
-	    <div>
-	    <a href="violationsage.html">Policy Violations Report</a>
-	    <br><br>
-	    </div>
+		<div>
+		<a href="violationsage.html">Policy Violations Report</a>
+		<br><br>
+		</div>
 
-	    <div>
-	    <a href="evaluations.html">Application Evaluations Report</a>
-	    <br><br>
+		<div>
+		<a href="evaluations.html">Application Evaluations Report</a>
+		<br><br>
 		</div>
 
 		<div>
@@ -188,9 +184,8 @@
 		<br><br>
 		</div>
 
-	    
+		
 
-       </div>
     </div>
 
 </body>


### PR DESCRIPTION
Before this PR it was mandatory to have a successmetrics.csv file to view any metrics in web view. This PR removes that limitation.
