### PR TITLE
Improve scanning coverage calculation

### DIFF
--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/service/ApplicationsDataService.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/service/ApplicationsDataService.java
@@ -6,7 +6,6 @@ import org.sonatype.cs.metrics.model.RiskRatio;
 import org.sonatype.cs.metrics.util.HelperService;
 import org.sonatype.cs.metrics.util.SqlStatements;
 import org.springframework.stereotype.Service;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -14,145 +13,139 @@ import java.util.Map;
 
 @Service
 public class ApplicationsDataService {
-    private DbService dbService;
+        private DbService dbService;
 
-    public ApplicationsDataService(DbService dbService) {
-        this.dbService = dbService;
-    }
-
-    public Map<String, Object> getApplicationData(
-            String tableName, Map<String, Object> periodsData) {
-        Map<String, Object> model = new HashMap<>();
-
-        List<DbRow> applicationsOnboardedData =
-                dbService.runSql(tableName, SqlStatements.APPLICATIONSONBOARDED);
-        int rows = applicationsOnboardedData.size();
-
-        String endPeriod = null;
-
-        int startPeriodCount = applicationsOnboardedData.get(0).getPointA();
-        int endPeriodCount = applicationsOnboardedData.get(rows - 1).getPointA();
-
-        int applicationsOnboardedInPeriod = applicationsOnboardedData.get(rows - 1).getPointA();
-
-        switch (tableName) {
-            case SqlStatements.METRICTABLENAME:
-                endPeriod = periodsData.get("endPeriod").toString();
-                break;
-
-            case SqlStatements.METRICP1TABLENAME:
-                endPeriod = periodsData.get("midPeriod").toString();
-                break;
-
-            case SqlStatements.METRICP2TABLENAME:
-                endPeriod = periodsData.get("endPeriod").toString();
-                break;
-            default:
+        public ApplicationsDataService(DbService dbService) {
+                this.dbService = dbService;
         }
 
-        int applicationsOnboardedInPeriodAvg = applicationsOnboardedInPeriod / rows;
-        if (applicationsOnboardedInPeriodAvg == 0) {
-            applicationsOnboardedInPeriodAvg = 1;
+        public Map<String, Object> getApplicationData(String tableName,
+                        Map<String, Object> periodsData) {
+                Map<String, Object> model = new HashMap<>();
+
+                List<DbRow> applicationsOnboardedData =
+                                dbService.runSql(tableName, SqlStatements.APPLICATIONSONBOARDED);
+                int rows = applicationsOnboardedData.size();
+
+                String endPeriod = null;
+
+                int startPeriodCount = applicationsOnboardedData.get(0).getPointA();
+                int endPeriodCount = applicationsOnboardedData.get(rows - 1).getPointA();
+
+                int applicationsOnboardedInPeriod =
+                                applicationsOnboardedData.get(rows - 1).getPointA();
+
+                switch (tableName) {
+                        case SqlStatements.METRICTABLENAME:
+                                endPeriod = periodsData.get("endPeriod").toString();
+                                break;
+
+                        case SqlStatements.METRICP1TABLENAME:
+                                endPeriod = periodsData.get("midPeriod").toString();
+                                break;
+
+                        case SqlStatements.METRICP2TABLENAME:
+                                endPeriod = periodsData.get("endPeriod").toString();
+                                break;
+                        default:
+                }
+
+                int applicationsOnboardedInPeriodAvg = applicationsOnboardedInPeriod / rows;
+                if (applicationsOnboardedInPeriodAvg == 0) {
+                        applicationsOnboardedInPeriodAvg = 1;
+                }
+
+                model.put("startPeriodCount", startPeriodCount);
+                model.put("endPeriodCount", endPeriodCount);
+                model.put("numberOfPeriods", rows);
+                model.put("applicationsOnboardedChart", applicationsOnboardedData);
+                model.put("applicationsOnboarded", applicationsOnboardedInPeriod);
+                model.put("applicationsOnboardedAvg", applicationsOnboardedInPeriodAvg);
+
+                model.put("applicationReport", applicationsOnboardedInPeriod == 1);
+
+                List<DbRow> numberOfScansData =
+                                dbService.runSql(tableName, SqlStatements.NUMBEROFSCANS);
+                int[] numberOfScans = HelperService.getPointsSumAndAverage(numberOfScansData);
+                model.put("numberOfScansChart", numberOfScansData);
+                model.put("numberOfScans", numberOfScans[0]);
+                model.put("numberOfScansAvg", numberOfScans[1]);
+
+                List<DbRow> numberOfScannedApplicationsData = dbService.runSql(tableName,
+                                SqlStatements.NUMBEROFSCANNEDAPPLICATIONS);
+                int[] numberOfScannedApplications = HelperService
+                                .getPointsSumAndAverage(numberOfScannedApplicationsData);
+                model.put("numberOfApplicationsScannedChart", numberOfScannedApplicationsData);
+                model.put("numberOfApplicationsScanned", numberOfScannedApplications[0]);
+                model.put("numberOfApplicationsScannedAvg", numberOfScannedApplications[1]);
+
+                List<Mttr> mttr = dbService.runSqlMttr(tableName, SqlStatements.MTTR);
+                model.put("mttrChart", mttr);
+
+                String applicationOpenViolations = SqlStatements.APPLICATIONSOPENVIOLATIONS
+                                + " where time_period_start = '" + endPeriod
+                                + "' group by application_name" + " order by 2 desc, 3 desc";
+                List<DbRow> aov = dbService.runSql(tableName, applicationOpenViolations);
+
+                String organisationOpenViolations = SqlStatements.ORGANISATIONSOPENVIOLATIONS
+                                + " where time_period_start = '" + endPeriod
+                                + "' group by organization_name" + " order by 2 desc, 3 desc";
+                List<DbRow> oov = dbService.runSql(tableName, organisationOpenViolations);
+
+                if (!aov.isEmpty()) {
+                        model.put("mostCriticalApplicationCount", aov.get(0).getPointA());
+                        model.put("leastCriticalApplicationCount",
+                                        aov.get(aov.size() - 1).getPointA());
+                        model.put("openCriticalViolationsAvg",
+                                        HelperService.getPointsSumAndAverage(aov)[1]);
+                        model.put("mostCriticalApplicationName", aov.get(0).getLabel());
+                        model.put("leastCriticalApplicationName",
+                                        aov.get(aov.size() - 1).getLabel());
+
+                        model.put("applicationsSecurityRemediation", dbService.runSql(tableName,
+                                        SqlStatements.APPLICATIONSSECURITYREMEDIATION));
+                        model.put("applicationsLicenseRemediation", dbService.runSql(tableName,
+                                        SqlStatements.APPLICATIONSLICENSEREMEDIATION));
+
+                        model.put("mostCriticalOrganisationsData", oov);
+                        model.put("mostCriticalApplicationsData", aov);
+
+                        model.put("mostScannedApplicationsData", dbService.runSql(tableName,
+                                        SqlStatements.MOSTSCANNEDAPPLICATIONS));
+                }
+
+                List<RiskRatio> riskRatios = new ArrayList<>();
+                dbService.runSql(tableName, SqlStatements.RISKRATIOCOMPONENTS)
+                                .forEach(timePeriod -> {
+                                        Double riskRatioValue = (Double
+                                                        .valueOf(timePeriod.getPointA())
+                                                        + Double.valueOf(timePeriod.getPointB()))
+                                                        / Double.valueOf(timePeriod.getPointC());
+
+                                        riskRatios.add(new RiskRatio(timePeriod.getLabel(),
+                                                        riskRatioValue));
+                                });
+                model.put("riskRatioChart", riskRatios);
+                model.put("riskRatioAtEndPeriod",
+                                riskRatios.get(riskRatios.size() - 1).getRiskRatioValue());
+                model.put("riskRatioAtStartPeriod",
+                                riskRatios.get(riskRatios.size() - 1).getRiskRatioValue());
+
+                return model;
         }
 
-        model.put("startPeriodCount", startPeriodCount);
-        model.put("endPeriodCount", endPeriodCount);
-        model.put("numberOfPeriods", rows);
-        model.put("applicationsOnboardedChart", applicationsOnboardedData);
-        model.put("applicationsOnboarded", applicationsOnboardedInPeriod);
-        model.put("applicationsOnboardedAvg", applicationsOnboardedInPeriodAvg);
+        public boolean applicationExists(String applicationName) {
+                List<DbRow> applications = dbService.runSql(SqlStatements.METRICTABLENAME,
+                                SqlStatements.LISTOFAPPLICATIONS);
+                boolean status = false;
 
-        model.put("applicationReport", applicationsOnboardedInPeriod == 1);
+                for (DbRow r : applications) {
+                        if (r.getLabel().equalsIgnoreCase(applicationName)) {
+                                status = true;
+                                break;
+                        }
+                }
 
-        List<DbRow> numberOfScansData = dbService.runSql(tableName, SqlStatements.NUMBEROFSCANS);
-        int[] numberOfScans = HelperService.getPointsSumAndAverage(numberOfScansData);
-        model.put("numberOfScansChart", numberOfScansData);
-        model.put("numberOfScans", numberOfScans[0]);
-        model.put("numberOfScansAvg", numberOfScans[1]);
-
-        List<DbRow> numberOfScannedApplicationsData =
-                dbService.runSql(tableName, SqlStatements.NUMBEROFSCANNEDAPPLICATIONS);
-        int[] numberOfScannedApplications =
-                HelperService.getPointsSumAndAverage(numberOfScannedApplicationsData);
-        model.put("numberOfApplicationsScannedChart", numberOfScannedApplicationsData);
-        model.put("numberOfApplicationsScanned", numberOfScannedApplications[0]);
-        model.put("numberOfApplicationsScannedAvg", numberOfScannedApplications[1]);
-
-        List<Mttr> mttr = dbService.runSqlMttr(tableName, SqlStatements.MTTR);
-        model.put("mttrChart", mttr);
-
-        String applicationOpenViolations =
-                SqlStatements.APPLICATIONSOPENVIOLATIONS
-                        + " where time_period_start = '"
-                        + endPeriod
-                        + "' group by application_name"
-                        + " order by 2 desc, 3 desc";
-        List<DbRow> aov = dbService.runSql(tableName, applicationOpenViolations);
-
-        String organisationOpenViolations =
-                SqlStatements.ORGANISATIONSOPENVIOLATIONS
-                        + " where time_period_start = '"
-                        + endPeriod
-                        + "' group by organization_name"
-                        + " order by 2 desc, 3 desc";
-        List<DbRow> oov = dbService.runSql(tableName, organisationOpenViolations);
-
-        if (!aov.isEmpty()) {
-            model.put("mostCriticalApplicationCount", aov.get(0).getPointA());
-            model.put("leastCriticalApplicationCount", aov.get(aov.size() - 1).getPointA());
-            model.put("openCriticalViolationsAvg", HelperService.getPointsSumAndAverage(aov)[1]);
-            model.put("mostCriticalApplicationName", aov.get(0).getLabel());
-            model.put("leastCriticalApplicationName", aov.get(aov.size() - 1).getLabel());
-
-            model.put(
-                    "applicationsSecurityRemediation",
-                    dbService.runSql(tableName, SqlStatements.APPLICATIONSSECURITYREMEDIATION));
-            model.put(
-                    "applicationsLicenseRemediation",
-                    dbService.runSql(tableName, SqlStatements.APPLICATIONSLICENSEREMEDIATION));
-
-            model.put("mostCriticalOrganisationsData", oov);
-            model.put("mostCriticalApplicationsData", aov);
-
-            model.put(
-                    "mostScannedApplicationsData",
-                    dbService.runSql(tableName, SqlStatements.MOSTSCANNEDAPPLICATIONS));
+                return status;
         }
-
-        List<RiskRatio> riskRatios = new ArrayList<>();
-        dbService
-                .runSql(tableName, SqlStatements.RISKRATIOCOMPONENTS)
-                .forEach(
-                        timePeriod -> {
-                            Double riskRatioValue =
-                                    (Double.valueOf(timePeriod.getPointA())
-                                                    + Double.valueOf(timePeriod.getPointB()))
-                                            / Double.valueOf(timePeriod.getPointC());
-
-                            riskRatios.add(new RiskRatio(timePeriod.getLabel(), riskRatioValue));
-                        });
-        model.put("riskRatioChart", riskRatios);
-        model.put(
-                "riskRatioAtEndPeriod", riskRatios.get(riskRatios.size() - 1).getRiskRatioValue());
-        model.put(
-                "riskRatioAtStartPeriod",
-                riskRatios.get(riskRatios.size() - 1).getRiskRatioValue());
-
-        return model;
-    }
-
-    public boolean applicationExists(String applicationName) {
-        List<DbRow> applications =
-                dbService.runSql(SqlStatements.METRICTABLENAME, SqlStatements.LISTOFAPPLICATIONS);
-        boolean status = false;
-
-        for (DbRow r : applications) {
-            if (r.getLabel().equalsIgnoreCase(applicationName)) {
-                status = true;
-                break;
-            }
-        }
-
-        return status;
-    }
 }

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/service/InsightsAnalysisService.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/service/InsightsAnalysisService.java
@@ -6,7 +6,6 @@ import org.sonatype.cs.metrics.model.DbRow;
 import org.sonatype.cs.metrics.util.HelperService;
 import org.sonatype.cs.metrics.util.SqlStatements;
 import org.springframework.stereotype.Service;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -15,428 +14,400 @@ import java.util.Map;
 
 @Service
 public class InsightsAnalysisService {
-    private static final Logger log = LoggerFactory.getLogger(InsightsAnalysisService.class);
+        private static final Logger log = LoggerFactory.getLogger(InsightsAnalysisService.class);
 
-    private MetricsService metricsService;
-    private PeriodsDataService periodsDataService;
-    private FileIoService fileIoService;
+        private MetricsService metricsService;
+        private PeriodsDataService periodsDataService;
+        private FileIoService fileIoService;
+        private DbService dbService;
 
-    public InsightsAnalysisService(
-            MetricsService metricsService,
-            PeriodsDataService periodsDataService,
-            FileIoService fileIoService) {
-        this.metricsService = metricsService;
-        this.periodsDataService = periodsDataService;
-        this.fileIoService = fileIoService;
-    }
-
-    public void writeInsightsAnalysisData(String timestamp) throws IOException {
-        log.info("Writing insights data file");
-
-        Map<String, Object> periodsData =
-                periodsDataService.getPeriodData(SqlStatements.METRICTABLENAME);
-        boolean doAnalysis = (boolean) periodsData.get("doAnalysis");
-
-        if (doAnalysis) {
-            Map<String, Object> analysisData = getInsightsAnalysisData(periodsData);
-            List<String[]> csvData = createCsvData(analysisData);
-
-            String csvFilename = fileIoService.makeFilename("insights", "csv", timestamp);
-
-            String beforeDateRange = "Before " + (String) periodsData.get("midPeriodDate1RangeStr");
-            String afterDateRange = "After " + (String) periodsData.get("midPeriodDate2RangeStr");
-
-            fileIoService.writeInsightsCsvFile(
-                    csvFilename, csvData, beforeDateRange, afterDateRange);
-
-            log.info("Created insights data file: {}", csvFilename);
-        }
-    }
-
-    public Map<String, Object> getInsightsAnalysisData(Map<String, Object> periodsData) {
-        Map<String, Object> model = new HashMap<>();
-
-        Map<String, Object> p1metrics =
-                metricsService.getMetrics(SqlStatements.METRICP1TABLENAME, periodsData);
-        Map<String, Object> p2metrics =
-                metricsService.getMetrics(SqlStatements.METRICP2TABLENAME, periodsData);
-
-        int appsInFirstPeriod = Integer.parseInt(String.valueOf(p1metrics.get("startPeriodCount")));
-        int p1numberOfPeriods = Integer.parseInt(String.valueOf(p1metrics.get("numberOfPeriods")));
-        int p2numberOfPeriods = Integer.parseInt(String.valueOf(p2metrics.get("numberOfPeriods")));
-
-        int onboardedAfter =
-                Integer.parseInt(String.valueOf(p2metrics.get("applicationsOnboarded")));
-        int onboardedBefore =
-                Integer.parseInt(String.valueOf(p1metrics.get("applicationsOnboarded")));
-
-        float scanningCoverageAfter =
-                this.calculatePct(
-                        Integer.parseInt(
-                                String.valueOf(p2metrics.get("numberOfApplicationsScannedAvg"))),
-                        onboardedAfter);
-        float scanningCoverageBefore =
-                this.calculatePct(
-                        Integer.parseInt(
-                                String.valueOf(p1metrics.get("numberOfApplicationsScannedAvg"))),
-                        onboardedBefore);
-
-        final String numberOfScansStr = "numberOfScans";
-        float totalScansAfter = Integer.parseInt(String.valueOf(p2metrics.get(numberOfScansStr)));
-        float totalScansBefore = Integer.parseInt(String.valueOf(p1metrics.get(numberOfScansStr)));
-
-        float scanningRateAfter =
-                Integer.parseInt(String.valueOf(p2metrics.get(numberOfScansStr)))
-                        / (float) p2numberOfPeriods;
-        float scanningRateBefore =
-                Integer.parseInt(String.valueOf(p1metrics.get(numberOfScansStr)))
-                        / (float) p1numberOfPeriods;
-
-        float scanningRateAfterAvg = scanningRateAfter / onboardedAfter;
-        float scanningRateBeforeAvg = scanningRateBefore / onboardedBefore;
-
-        DbRow discoveredSecurityTotalAfter =
-                (DbRow) p2metrics.get("discoveredSecurityViolationsTotal");
-        DbRow discoveredSecurityTotalBefore =
-                (DbRow) p1metrics.get("discoveredSecurityViolationsTotal");
-
-        float discoveryRateCriticalsBefore =
-                ((float) discoveredSecurityTotalBefore.getPointA() / p1numberOfPeriods)
-                        / onboardedBefore;
-        float discoveryRateCriticalsAfter =
-                ((float) discoveredSecurityTotalAfter.getPointA() / p2numberOfPeriods)
-                        / onboardedAfter;
-
-        DbRow fixedSecurityCriticalsTotalAfter =
-                (DbRow) p2metrics.get("fixedSecurityViolationsTotal");
-        DbRow fixedSecurityCriticalsTotalBefore =
-                (DbRow) p1metrics.get("fixedSecurityViolationsTotal");
-
-        float fixedRateCriticalsBefore =
-                ((float) fixedSecurityCriticalsTotalBefore.getPointA() / p1numberOfPeriods)
-                        / onboardedBefore;
-        float fixedRateCriticalsAfter =
-                ((float) fixedSecurityCriticalsTotalAfter.getPointA() / p2numberOfPeriods)
-                        / onboardedAfter;
-
-        float backlogReductionCriticalsRateBefore =
-                (float) p1metrics.get("backlogReductionRateCritical");
-        float backlogReductionCriticalsRateAfter =
-                (float) p2metrics.get("backlogReductionRateCritical");
-
-        model.put("totalOnboardedBefore", onboardedBefore);
-        model.put("totalOnboardedAfter", onboardedAfter);
-        model.put("totalOnboardedDiff", this.formatFloat((float) onboardedAfter - onboardedBefore));
-        model.put("totalOnboarded", this.calculateChangePctg(onboardedBefore, onboardedAfter));
-        model.put(
-                "totalOnboardedIncrease",
-                this.calculateChangeMultiple(onboardedBefore, onboardedAfter));
-
-        float onboardingRateBefore =
-                (float) (onboardedBefore - appsInFirstPeriod) / p1numberOfPeriods;
-        float onboardingRateAfter = (float) (onboardedAfter - onboardedBefore) / p2numberOfPeriods;
-
-        model.put("onboardingRateBefore", this.formatFloat(onboardingRateBefore));
-        model.put("onboardingRateAfter", this.formatFloat(onboardingRateAfter));
-        model.put(
-                "onboardingRateDiff", this.formatFloat(onboardingRateAfter - onboardingRateBefore));
-        model.put(
-                "onboardingRate",
-                this.calculateChangePctg(onboardingRateAfter, onboardingRateAfter));
-        model.put(
-                "onboardingRateIncrease",
-                this.calculateChangeMultiple(onboardingRateBefore, onboardingRateAfter));
-
-        model.put("scanningCoverageBefore", this.formatFloat(scanningCoverageBefore));
-        model.put("scanningCoverageAfter", this.formatFloat(scanningCoverageAfter));
-        model.put(
-                "scanningCoverageDiff",
-                this.formatFloat(scanningCoverageAfter - scanningCoverageBefore));
-        model.put(
-                "scanningCoverage",
-                this.calculateChangePctg(scanningCoverageBefore, scanningCoverageAfter));
-        model.put(
-                "scanningCoverageIncrease",
-                this.calculateChangeMultiple(scanningCoverageBefore, scanningCoverageAfter));
-
-        model.put("scanningRateBefore", this.formatFloat(scanningRateBefore));
-        model.put("scanningRateAfter", this.formatFloat(scanningRateAfter));
-        model.put("scanningRateDiff", this.formatFloat(scanningRateAfter - scanningRateBefore));
-        model.put("scanningRate", this.calculateChangePctg(scanningRateBefore, scanningRateAfter));
-        model.put(
-                "scanningRateIncrease",
-                this.calculateChangeMultiple(scanningRateBefore, scanningRateAfter));
-
-        model.put("avgScansBefore", this.formatFloat(scanningRateBeforeAvg));
-        model.put("avgScansAfter", this.formatFloat(scanningRateAfterAvg));
-        model.put("avgScansDiff", this.formatFloat(scanningRateAfterAvg - scanningRateBeforeAvg));
-        model.put(
-                "avgScans", this.calculateChangePctg(scanningRateBeforeAvg, scanningRateAfterAvg));
-        model.put(
-                "avgScansIncrease",
-                this.calculateChangeMultiple(scanningRateBeforeAvg, scanningRateAfterAvg));
-
-        model.put("discoveryRateCriticalsBefore", this.formatFloat(discoveryRateCriticalsBefore));
-        model.put("discoveryRateCriticalsAfter", this.formatFloat(discoveryRateCriticalsAfter));
-        model.put(
-                "discoveryRateCriticalsDiff",
-                this.formatFloat(discoveryRateCriticalsAfter - discoveryRateCriticalsBefore));
-        model.put(
-                "discoveryRateCriticals",
-                this.calculateChangePctg(
-                        discoveryRateCriticalsBefore, discoveryRateCriticalsAfter));
-        model.put(
-                "discoveryRateCriticalsIncrease",
-                this.calculateChangeMultiple(
-                        discoveryRateCriticalsBefore, discoveryRateCriticalsAfter));
-
-        model.put("fixingRateCriticalsBefore", this.formatFloat(fixedRateCriticalsBefore));
-        model.put("fixingRateCriticalsAfter", this.formatFloat(fixedRateCriticalsAfter));
-        model.put(
-                "fixingRateCriticalsDiff",
-                this.formatFloat(fixedRateCriticalsAfter - fixedRateCriticalsBefore));
-        model.put(
-                "fixingRateCriticals",
-                this.calculateChangePctg(fixedRateCriticalsBefore, fixedRateCriticalsAfter));
-        model.put(
-                "fixingRateCriticalsIncrease",
-                this.calculateChangeMultiple(fixedRateCriticalsBefore, fixedRateCriticalsAfter));
-
-        model.put(
-                "backlogReductionCriticalsRateBefore",
-                this.formatFloat(backlogReductionCriticalsRateBefore));
-        model.put(
-                "backlogReductionCriticalsRateAfter",
-                this.formatFloat(backlogReductionCriticalsRateAfter));
-        model.put(
-                "backlogReductionCriticalsRateDiff",
-                this.formatFloat(
-                        backlogReductionCriticalsRateAfter - backlogReductionCriticalsRateBefore));
-        model.put(
-                "backlogReductionCriticalsRate",
-                this.calculateChangePctg(
-                        backlogReductionCriticalsRateBefore, backlogReductionCriticalsRateAfter));
-        model.put(
-                "backlogReductionCriticalsRateIncrease",
-                this.calculateChangeMultiple(
-                        backlogReductionCriticalsRateBefore, backlogReductionCriticalsRateAfter));
-
-        Double riskRatioBefore = (Double) p1metrics.get("riskRatioAtStartPeriod");
-        Double riskRatioAfter = (Double) p2metrics.get("riskRatioAtEndPeriod");
-
-        model.put("riskRatioBefore", riskRatioBefore);
-        model.put("riskRatioAfter", riskRatioAfter);
-        model.put("riskRatioDiff", riskRatioAfter - riskRatioBefore);
-        model.put("riskRatio", this.calculateChangePctg(riskRatioBefore, riskRatioAfter));
-        model.put(
-                "riskRatioIncrease", this.calculateChangeMultiple(riskRatioBefore, riskRatioAfter));
-
-        String[] mttrCriticalsBefore = (String[]) p1metrics.get("mttrAvg");
-        String[] mttrCriticalsAfter = (String[]) p2metrics.get("mttrAvg");
-
-        model.put("mttrCriticalsBefore", Integer.parseInt(mttrCriticalsBefore[0]));
-        model.put("mttrCriticalsAfter", Integer.parseInt(mttrCriticalsAfter[0]));
-        model.put(
-                "mttrCriticalsDiff",
-                this.formatFloat(
-                        (float) Integer.parseInt(mttrCriticalsAfter[0])
-                                - Integer.parseInt(mttrCriticalsBefore[0])));
-        model.put(
-                "mttrCriticals",
-                this.calculateChangePctg(
-                        Integer.parseInt(mttrCriticalsBefore[0]),
-                        Integer.parseInt(mttrCriticalsAfter[0])));
-        model.put(
-                "mttrCriticalsIncrease",
-                this.calculateChangeMultiple(
-                        Integer.parseInt(mttrCriticalsBefore[0]),
-                        Integer.parseInt(mttrCriticalsAfter[0])));
-
-        model.put("totalScansBefore", totalScansBefore);
-        model.put("totalScansAfter", totalScansAfter);
-        model.put("totalScansDiff", this.formatFloat(totalScansAfter - totalScansBefore));
-        model.put("totalScans", this.calculateChangePctg(totalScansBefore, totalScansAfter));
-        model.put(
-                "totalScansIncrease",
-                this.calculateChangeMultiple(totalScansBefore, totalScansAfter));
-
-        return model;
-    }
-
-    private String formatFloat(float f) {
-        return String.format("%.2f", f);
-    }
-
-    private String calculateChangePctg(float before, float after) {
-        float result = 0;
-
-        if (after > 0 && before > 0) {
-            result = (((after - before) / before) * 100);
+        public InsightsAnalysisService(MetricsService metricsService,
+                        PeriodsDataService periodsDataService, FileIoService fileIoService,
+                        DbService dbService) {
+                this.metricsService = metricsService;
+                this.periodsDataService = periodsDataService;
+                this.fileIoService = fileIoService;
+                this.dbService = dbService;
         }
 
-        return String.format("%.2f", result);
-    }
+        public void writeInsightsAnalysisData(String timestamp) throws IOException {
+                log.info("Writing insights data file");
 
-    private String calculateChangePctg(Double before, Double after) {
-        Double result = 0D;
+                Map<String, Object> periodsData =
+                                periodsDataService.getPeriodData(SqlStatements.METRICTABLENAME);
+                boolean doAnalysis = (boolean) periodsData.get("doAnalysis");
 
-        if (after > 0 && before > 0) {
-            result = (((after - before) / before) * 100);
+                if (doAnalysis) {
+                        Map<String, Object> analysisData = getInsightsAnalysisData(periodsData);
+                        List<String[]> csvData = createCsvData(analysisData);
+
+                        String csvFilename =
+                                        fileIoService.makeFilename("insights", "csv", timestamp);
+
+                        String beforeDateRange = "Before "
+                                        + (String) periodsData.get("midPeriodDate1RangeStr");
+                        String afterDateRange = "After "
+                                        + (String) periodsData.get("midPeriodDate2RangeStr");
+
+                        fileIoService.writeInsightsCsvFile(csvFilename, csvData, beforeDateRange,
+                                        afterDateRange);
+
+                        log.info("Created insights data file: {}", csvFilename);
+                }
         }
 
-        return String.format("%.2f", result);
-    }
+        public Map<String, Object> getInsightsAnalysisData(Map<String, Object> periodsData) {
+                Map<String, Object> model = new HashMap<>();
 
-    private String calculateChangeMultiple(float before, float after) {
-        float result = 0;
+                Map<String, Object> p1metrics = metricsService
+                                .getMetrics(SqlStatements.METRICP1TABLENAME, periodsData);
+                Map<String, Object> p2metrics = metricsService
+                                .getMetrics(SqlStatements.METRICP2TABLENAME, periodsData);
 
-        if (after > 0 && before > 0) {
-            result = after / before;
+
+                int appsInFirstPeriod =
+                                Integer.parseInt(String.valueOf(p1metrics.get("startPeriodCount")));
+                int p1numberOfPeriods =
+                                Integer.parseInt(String.valueOf(p1metrics.get("numberOfPeriods")));
+                int p2numberOfPeriods =
+                                Integer.parseInt(String.valueOf(p2metrics.get("numberOfPeriods")));
+
+                int onboardedAfter = Integer
+                                .parseInt(String.valueOf(p2metrics.get("applicationsOnboarded")));
+                int onboardedBefore = Integer
+                                .parseInt(String.valueOf(p1metrics.get("applicationsOnboarded")));
+
+
+                List<DbRow> p1_scanning_coverage = dbService.runSql(SqlStatements.METRICP1TABLENAME,
+                                SqlStatements.SCANNINGCOVERAGE);
+                List<DbRow> p2_scanning_coverage = dbService.runSql(SqlStatements.METRICP2TABLENAME,
+                                SqlStatements.SCANNINGCOVERAGE);
+
+
+                double scanningCoverageBefore = p1_scanning_coverage.stream()
+                                .map(elt -> Double.valueOf(elt.getPointA()) / elt.getPointB())
+                                .mapToDouble(Double::doubleValue).average().getAsDouble() * 100.0;
+                double scanningCoverageAfter = p2_scanning_coverage.stream()
+                                .map(elt -> Double.valueOf(elt.getPointA()) / elt.getPointB())
+                                .mapToDouble(Double::doubleValue).average().getAsDouble() * 100.0;
+
+                final String numberOfScansStr = "numberOfScans";
+                float totalScansAfter =
+                                Integer.parseInt(String.valueOf(p2metrics.get(numberOfScansStr)));
+                float totalScansBefore =
+                                Integer.parseInt(String.valueOf(p1metrics.get(numberOfScansStr)));
+
+                float scanningRateAfter =
+                                Integer.parseInt(String.valueOf(p2metrics.get(numberOfScansStr)))
+                                                / (float) p2numberOfPeriods;
+                float scanningRateBefore =
+                                Integer.parseInt(String.valueOf(p1metrics.get(numberOfScansStr)))
+                                                / (float) p1numberOfPeriods;
+
+                float scanningRateAfterAvg = scanningRateAfter / onboardedAfter;
+                float scanningRateBeforeAvg = scanningRateBefore / onboardedBefore;
+
+                DbRow discoveredSecurityTotalAfter =
+                                (DbRow) p2metrics.get("discoveredSecurityViolationsTotal");
+                DbRow discoveredSecurityTotalBefore =
+                                (DbRow) p1metrics.get("discoveredSecurityViolationsTotal");
+
+                float discoveryRateCriticalsBefore =
+                                ((float) discoveredSecurityTotalBefore.getPointA()
+                                                / p1numberOfPeriods) / onboardedBefore;
+                float discoveryRateCriticalsAfter =
+                                ((float) discoveredSecurityTotalAfter.getPointA()
+                                                / p2numberOfPeriods) / onboardedAfter;
+
+                DbRow fixedSecurityCriticalsTotalAfter =
+                                (DbRow) p2metrics.get("fixedSecurityViolationsTotal");
+                DbRow fixedSecurityCriticalsTotalBefore =
+                                (DbRow) p1metrics.get("fixedSecurityViolationsTotal");
+
+                float fixedRateCriticalsBefore =
+                                ((float) fixedSecurityCriticalsTotalBefore.getPointA()
+                                                / p1numberOfPeriods) / onboardedBefore;
+                float fixedRateCriticalsAfter =
+                                ((float) fixedSecurityCriticalsTotalAfter.getPointA()
+                                                / p2numberOfPeriods) / onboardedAfter;
+
+                float backlogReductionCriticalsRateBefore =
+                                (float) p1metrics.get("backlogReductionRateCritical");
+                float backlogReductionCriticalsRateAfter =
+                                (float) p2metrics.get("backlogReductionRateCritical");
+
+                model.put("totalOnboardedBefore", onboardedBefore);
+                model.put("totalOnboardedAfter", onboardedAfter);
+                model.put("totalOnboardedDiff",
+                                this.formatFloat((float) onboardedAfter - onboardedBefore));
+                model.put("totalOnboarded",
+                                this.calculateChangePctg(onboardedBefore, onboardedAfter));
+                model.put("totalOnboardedIncrease",
+                                this.calculateChangeMultiple(onboardedBefore, onboardedAfter));
+
+                float onboardingRateBefore =
+                                (float) (onboardedBefore - appsInFirstPeriod) / p1numberOfPeriods;
+                float onboardingRateAfter =
+                                (float) (onboardedAfter - onboardedBefore) / p2numberOfPeriods;
+
+                model.put("onboardingRateBefore", this.formatFloat(onboardingRateBefore));
+                model.put("onboardingRateAfter", this.formatFloat(onboardingRateAfter));
+                model.put("onboardingRateDiff",
+                                this.formatFloat(onboardingRateAfter - onboardingRateBefore));
+                model.put("onboardingRate",
+                                this.calculateChangePctg(onboardingRateAfter, onboardingRateAfter));
+                model.put("onboardingRateIncrease", this.calculateChangeMultiple(
+                                onboardingRateBefore, onboardingRateAfter));
+
+                model.put("scanningCoverageBefore", this.formatDouble(scanningCoverageBefore));
+                model.put("scanningCoverageAfter", this.formatDouble(scanningCoverageAfter));
+                model.put("scanningCoverageDiff",
+                                this.formatDouble(scanningCoverageAfter - scanningCoverageBefore));
+                model.put("scanningCoverage", this.calculateChangePctg(scanningCoverageBefore,
+                                scanningCoverageAfter));
+                model.put("scanningCoverageIncrease", this.calculateChangeMultiple(
+                                scanningCoverageBefore, scanningCoverageAfter));
+
+                model.put("scanningRateBefore", this.formatFloat(scanningRateBefore));
+                model.put("scanningRateAfter", this.formatFloat(scanningRateAfter));
+                model.put("scanningRateDiff",
+                                this.formatFloat(scanningRateAfter - scanningRateBefore));
+                model.put("scanningRate",
+                                this.calculateChangePctg(scanningRateBefore, scanningRateAfter));
+                model.put("scanningRateIncrease", this.calculateChangeMultiple(scanningRateBefore,
+                                scanningRateAfter));
+
+                model.put("avgScansBefore", this.formatFloat(scanningRateBeforeAvg));
+                model.put("avgScansAfter", this.formatFloat(scanningRateAfterAvg));
+                model.put("avgScansDiff",
+                                this.formatFloat(scanningRateAfterAvg - scanningRateBeforeAvg));
+                model.put("avgScans", this.calculateChangePctg(scanningRateBeforeAvg,
+                                scanningRateAfterAvg));
+                model.put("avgScansIncrease", this.calculateChangeMultiple(scanningRateBeforeAvg,
+                                scanningRateAfterAvg));
+
+                model.put("discoveryRateCriticalsBefore",
+                                this.formatFloat(discoveryRateCriticalsBefore));
+                model.put("discoveryRateCriticalsAfter",
+                                this.formatFloat(discoveryRateCriticalsAfter));
+                model.put("discoveryRateCriticalsDiff", this.formatFloat(
+                                discoveryRateCriticalsAfter - discoveryRateCriticalsBefore));
+                model.put("discoveryRateCriticals", this.calculateChangePctg(
+                                discoveryRateCriticalsBefore, discoveryRateCriticalsAfter));
+                model.put("discoveryRateCriticalsIncrease", this.calculateChangeMultiple(
+                                discoveryRateCriticalsBefore, discoveryRateCriticalsAfter));
+
+                model.put("fixingRateCriticalsBefore", this.formatFloat(fixedRateCriticalsBefore));
+                model.put("fixingRateCriticalsAfter", this.formatFloat(fixedRateCriticalsAfter));
+                model.put("fixingRateCriticalsDiff", this
+                                .formatFloat(fixedRateCriticalsAfter - fixedRateCriticalsBefore));
+                model.put("fixingRateCriticals", this.calculateChangePctg(fixedRateCriticalsBefore,
+                                fixedRateCriticalsAfter));
+                model.put("fixingRateCriticalsIncrease", this.calculateChangeMultiple(
+                                fixedRateCriticalsBefore, fixedRateCriticalsAfter));
+
+                model.put("backlogReductionCriticalsRateBefore",
+                                this.formatFloat(backlogReductionCriticalsRateBefore));
+                model.put("backlogReductionCriticalsRateAfter",
+                                this.formatFloat(backlogReductionCriticalsRateAfter));
+                model.put("backlogReductionCriticalsRateDiff",
+                                this.formatFloat(backlogReductionCriticalsRateAfter
+                                                - backlogReductionCriticalsRateBefore));
+                model.put("backlogReductionCriticalsRate",
+                                this.calculateChangePctg(backlogReductionCriticalsRateBefore,
+                                                backlogReductionCriticalsRateAfter));
+                model.put("backlogReductionCriticalsRateIncrease",
+                                this.calculateChangeMultiple(backlogReductionCriticalsRateBefore,
+                                                backlogReductionCriticalsRateAfter));
+
+                Double riskRatioBefore = (Double) p1metrics.get("riskRatioAtStartPeriod");
+                Double riskRatioAfter = (Double) p2metrics.get("riskRatioAtEndPeriod");
+
+                model.put("riskRatioBefore", riskRatioBefore);
+                model.put("riskRatioAfter", riskRatioAfter);
+                model.put("riskRatioDiff", riskRatioAfter - riskRatioBefore);
+                model.put("riskRatio", this.calculateChangePctg(riskRatioBefore, riskRatioAfter));
+                model.put("riskRatioIncrease",
+                                this.calculateChangeMultiple(riskRatioBefore, riskRatioAfter));
+
+                String[] mttrCriticalsBefore = (String[]) p1metrics.get("mttrAvg");
+                String[] mttrCriticalsAfter = (String[]) p2metrics.get("mttrAvg");
+
+                model.put("mttrCriticalsBefore", Integer.parseInt(mttrCriticalsBefore[0]));
+                model.put("mttrCriticalsAfter", Integer.parseInt(mttrCriticalsAfter[0]));
+                model.put("mttrCriticalsDiff",
+                                this.formatFloat((float) Integer.parseInt(mttrCriticalsAfter[0])
+                                                - Integer.parseInt(mttrCriticalsBefore[0])));
+                model.put("mttrCriticals",
+                                this.calculateChangePctg(Integer.parseInt(mttrCriticalsBefore[0]),
+                                                Integer.parseInt(mttrCriticalsAfter[0])));
+                model.put("mttrCriticalsIncrease",
+                                this.calculateChangeMultiple(
+                                                Integer.parseInt(mttrCriticalsBefore[0]),
+                                                Integer.parseInt(mttrCriticalsAfter[0])));
+
+                model.put("totalScansBefore", totalScansBefore);
+                model.put("totalScansAfter", totalScansAfter);
+                model.put("totalScansDiff", this.formatFloat(totalScansAfter - totalScansBefore));
+                model.put("totalScans",
+                                this.calculateChangePctg(totalScansBefore, totalScansAfter));
+                model.put("totalScansIncrease",
+                                this.calculateChangeMultiple(totalScansBefore, totalScansAfter));
+
+                return model;
         }
 
-        return String.format("%.2f", result);
-    }
-
-    private String calculateChangeMultiple(Double before, Double after) {
-        Double result = 0D;
-
-        if (after > 0 && before > 0) {
-            result = after / before;
+        private String formatFloat(float f) {
+                return String.format("%.2f", f);
         }
 
-        return String.format("%.2f", result);
-    }
-
-    private float calculatePct(float after, float before) {
-        float result = 0;
-
-        if (after > 0 && before > 0) {
-            result = ((after / before) * 100);
+        private String formatDouble(Double d) {
+                return String.format("%.2f", d);
         }
 
-        return result;
-    }
+        private String calculateChangePctg(float before, float after) {
+                float result = 0;
 
-    private List<String[]> createCsvData(Map<String, Object> analysisData) {
+                if (after > 0 && before > 0) {
+                        result = (((after - before) / before) * 100);
+                }
 
-        List<String[]> data = new ArrayList<>();
+                return String.format("%.2f", result);
+        }
 
-        data.add(
-                new String[] {
-                    "Total Onboarded Apps (# of apps)",
-                    String.valueOf(analysisData.get("totalOnboardedBefore")),
-                    String.valueOf(analysisData.get("totalOnboardedAfter")),
-                    String.valueOf(analysisData.get("totalOnboardedDiff")),
-                    String.valueOf(analysisData.get("totalOnboarded")),
-                    String.valueOf(analysisData.get("totalOnboardedIncrease"))
-                });
+        private String calculateChangePctg(Double before, Double after) {
+                Double result = 0D;
 
-        data.add(
-                new String[] {
-                    "Onboarding Rate (apps/period)",
-                    String.valueOf(analysisData.get("onboardingRateBefore")),
-                    String.valueOf(analysisData.get("onboardingRateAfter")),
-                    String.valueOf(analysisData.get("onboardingRateDiff")),
-                    String.valueOf(analysisData.get("onboardingRate")),
-                    String.valueOf(analysisData.get("onboardingRateIncrease"))
-                });
+                if (after > 0 && before > 0) {
+                        result = (((after - before) / before) * 100);
+                }
 
-        data.add(
-                new String[] {
-                    "Total Scans",
-                    String.valueOf(analysisData.get("totalScansBefore")),
-                    String.valueOf(analysisData.get("totalScansAfter")),
-                    String.valueOf(analysisData.get("totalScansDiff")),
-                    String.valueOf(analysisData.get("totalScans")),
-                    String.valueOf(analysisData.get("totalScansIncrease"))
-                });
+                return String.format("%.2f", result);
+        }
 
-        data.add(
-                new String[] {
-                    "Scanning Coverage %(apps scanned at least once/period)",
-                    String.valueOf(analysisData.get("scanningCoverageBefore")),
-                    String.valueOf(analysisData.get("scanningCoverageAfter")),
-                    String.valueOf(analysisData.get("scanningCoverageDiff")),
-                    String.valueOf(analysisData.get("scanningCoverage")),
-                    String.valueOf(analysisData.get("scanningCoverageIncrease"))
-                });
+        private String calculateChangeMultiple(float before, float after) {
+                float result = 0;
 
-        data.add(
-                new String[] {
-                    "Scanning Rate (total scans per period)",
-                    String.valueOf(analysisData.get("scanningRateBefore")),
-                    String.valueOf(analysisData.get("scanningRateAfter")),
-                    String.valueOf(analysisData.get("scanningRateDiff")),
-                    String.valueOf(analysisData.get("scanningRate")),
-                    String.valueOf(analysisData.get("scanningRateIncrease"))
-                });
+                if (after > 0 && before > 0) {
+                        result = after / before;
+                }
 
-        data.add(
-                new String[] {
-                    "Average Scans per App (scanning rate/apps)",
-                    String.valueOf(analysisData.get("avgScansBefore")),
-                    String.valueOf(analysisData.get("avgScansAfter")),
-                    String.valueOf(analysisData.get("avgScansDiff")),
-                    String.valueOf(analysisData.get("avgScans")),
-                    String.valueOf(analysisData.get("avgScansIncrease"))
-                });
+                return String.format("%.2f", result);
+        }
 
-        data.add(
-                new String[] {
-                    "Discovery Rate Criticals (# of discovered Critical violations/period & app)",
-                    String.valueOf(analysisData.get("discoveryRateCriticalsBefore")),
-                    String.valueOf(analysisData.get("discoveryRateCriticalsAfter")),
-                    String.valueOf(analysisData.get("discoveryRateCriticalsDiff")),
-                    String.valueOf(analysisData.get("discoveryRateCriticals")),
-                    String.valueOf(analysisData.get("discoveryRateCriticalsIncrease"))
-                });
+        private String calculateChangeMultiple(Double before, Double after) {
+                Double result = 0D;
 
-        data.add(
-                new String[] {
-                    "Fixing Rate Criticals (# of fixed Critical violations/period & app)",
-                    String.valueOf(analysisData.get("fixingRateCriticalsBefore")),
-                    String.valueOf(analysisData.get("fixingRateCriticalsAfter")),
-                    String.valueOf(analysisData.get("fixingRateCriticalsDiff")),
-                    String.valueOf(analysisData.get("fixingRateCriticals")),
-                    String.valueOf(analysisData.get("fixingRateCriticalsIncrease"))
-                });
+                if (after > 0 && before > 0) {
+                        result = after / before;
+                }
 
-        data.add(
-                new String[] {
-                    "Backlog Reduction Rate Criticals %(# of fixed / # of discovered)",
-                    String.valueOf(analysisData.get("backlogReductionCriticalsRateBefore")),
-                    String.valueOf(analysisData.get("backlogReductionCriticalsRateAfter")),
-                    String.valueOf(analysisData.get("backlogReductionCriticalsRateDiff")),
-                    String.valueOf(analysisData.get("backlogReductionCriticalsRate")),
-                    String.valueOf(analysisData.get("backlogReductionCriticalsRateIncrease"))
-                });
+                return String.format("%.2f", result);
+        }
 
-        data.add(
-                new String[] {
-                    "Risk Ratio (# of Critical violations / # of apps)",
-                    String.valueOf(
-                            HelperService.roundDouble(
-                                    (Double) analysisData.get("riskRatioBefore"), 1)),
-                    String.valueOf(
-                            HelperService.roundDouble(
-                                    (Double) analysisData.get("riskRatioAfter"), 1)),
-                    String.valueOf(
-                            HelperService.roundDouble(
-                                    (Double) analysisData.get("riskRatioDiff"), 1)),
-                    String.valueOf(analysisData.get("riskRatio")),
-                    String.valueOf(analysisData.get("riskRatioIncrease"))
-                });
+        private float calculatePct(float after, float before) {
+                float result = 0;
 
-        data.add(
-                new String[] {
-                    "MTTR Criticals (average # of days to fix Critical violations)",
-                    String.valueOf(analysisData.get("mttrCriticalsBefore")),
-                    String.valueOf(analysisData.get("mttrCriticalsAfter")),
-                    String.valueOf(analysisData.get("mttrCriticalsDiff")),
-                    String.valueOf(analysisData.get("mttrCriticals")),
-                    String.valueOf(analysisData.get("mttrCriticalsIncrease"))
-                });
+                if (after > 0 && before > 0) {
+                        result = ((after / before) * 100);
+                }
 
-        return data;
-    }
+                return result;
+        }
+
+        private List<String[]> createCsvData(Map<String, Object> analysisData) {
+
+                List<String[]> data = new ArrayList<>();
+
+                data.add(new String[] {"Total Onboarded Apps (# of apps)",
+                                String.valueOf(analysisData.get("totalOnboardedBefore")),
+                                String.valueOf(analysisData.get("totalOnboardedAfter")),
+                                String.valueOf(analysisData.get("totalOnboardedDiff")),
+                                String.valueOf(analysisData.get("totalOnboarded")),
+                                String.valueOf(analysisData.get("totalOnboardedIncrease"))});
+
+                data.add(new String[] {"Onboarding Rate (apps/period)",
+                                String.valueOf(analysisData.get("onboardingRateBefore")),
+                                String.valueOf(analysisData.get("onboardingRateAfter")),
+                                String.valueOf(analysisData.get("onboardingRateDiff")),
+                                String.valueOf(analysisData.get("onboardingRate")),
+                                String.valueOf(analysisData.get("onboardingRateIncrease"))});
+
+                data.add(new String[] {"Total Scans",
+                                String.valueOf(analysisData.get("totalScansBefore")),
+                                String.valueOf(analysisData.get("totalScansAfter")),
+                                String.valueOf(analysisData.get("totalScansDiff")),
+                                String.valueOf(analysisData.get("totalScans")),
+                                String.valueOf(analysisData.get("totalScansIncrease"))});
+
+                data.add(new String[] {"Scanning Coverage %(apps scanned at least once/period)",
+                                String.valueOf(analysisData.get("scanningCoverageBefore")),
+                                String.valueOf(analysisData.get("scanningCoverageAfter")),
+                                String.valueOf(analysisData.get("scanningCoverageDiff")),
+                                String.valueOf(analysisData.get("scanningCoverage")),
+                                String.valueOf(analysisData.get("scanningCoverageIncrease"))});
+
+                data.add(new String[] {"Scanning Rate (total scans per period)",
+                                String.valueOf(analysisData.get("scanningRateBefore")),
+                                String.valueOf(analysisData.get("scanningRateAfter")),
+                                String.valueOf(analysisData.get("scanningRateDiff")),
+                                String.valueOf(analysisData.get("scanningRate")),
+                                String.valueOf(analysisData.get("scanningRateIncrease"))});
+
+                data.add(new String[] {"Average Scans per App (scanning rate/apps)",
+                                String.valueOf(analysisData.get("avgScansBefore")),
+                                String.valueOf(analysisData.get("avgScansAfter")),
+                                String.valueOf(analysisData.get("avgScansDiff")),
+                                String.valueOf(analysisData.get("avgScans")),
+                                String.valueOf(analysisData.get("avgScansIncrease"))});
+
+                data.add(new String[] {
+                                "Discovery Rate Criticals (# of discovered Critical violations/period & app)",
+                                String.valueOf(analysisData.get("discoveryRateCriticalsBefore")),
+                                String.valueOf(analysisData.get("discoveryRateCriticalsAfter")),
+                                String.valueOf(analysisData.get("discoveryRateCriticalsDiff")),
+                                String.valueOf(analysisData.get("discoveryRateCriticals")),
+                                String.valueOf(analysisData
+                                                .get("discoveryRateCriticalsIncrease"))});
+
+                data.add(new String[] {
+                                "Fixing Rate Criticals (# of fixed Critical violations/period & app)",
+                                String.valueOf(analysisData.get("fixingRateCriticalsBefore")),
+                                String.valueOf(analysisData.get("fixingRateCriticalsAfter")),
+                                String.valueOf(analysisData.get("fixingRateCriticalsDiff")),
+                                String.valueOf(analysisData.get("fixingRateCriticals")),
+                                String.valueOf(analysisData.get("fixingRateCriticalsIncrease"))});
+
+                data.add(new String[] {
+                                "Backlog Reduction Rate Criticals %(# of fixed / # of discovered)",
+                                String.valueOf(analysisData
+                                                .get("backlogReductionCriticalsRateBefore")),
+                                String.valueOf(analysisData
+                                                .get("backlogReductionCriticalsRateAfter")),
+                                String.valueOf(analysisData
+                                                .get("backlogReductionCriticalsRateDiff")),
+                                String.valueOf(analysisData.get("backlogReductionCriticalsRate")),
+                                String.valueOf(analysisData
+                                                .get("backlogReductionCriticalsRateIncrease"))});
+
+                data.add(new String[] {"Risk Ratio (# of Critical violations / # of apps)",
+                                String.valueOf(HelperService.roundDouble(
+                                                (Double) analysisData.get("riskRatioBefore"), 1)),
+                                String.valueOf(HelperService.roundDouble(
+                                                (Double) analysisData.get("riskRatioAfter"), 1)),
+                                String.valueOf(HelperService.roundDouble(
+                                                (Double) analysisData.get("riskRatioDiff"), 1)),
+                                String.valueOf(analysisData.get("riskRatio")),
+                                String.valueOf(analysisData.get("riskRatioIncrease"))});
+
+                data.add(new String[] {
+                                "MTTR Criticals (average # of days to fix Critical violations)",
+                                String.valueOf(analysisData.get("mttrCriticalsBefore")),
+                                String.valueOf(analysisData.get("mttrCriticalsAfter")),
+                                String.valueOf(analysisData.get("mttrCriticalsDiff")),
+                                String.valueOf(analysisData.get("mttrCriticals")),
+                                String.valueOf(analysisData.get("mttrCriticalsIncrease"))});
+
+                return data;
+        }
 }

--- a/view-metrics/src/main/java/org/sonatype/cs/metrics/util/SqlStatements.java
+++ b/view-metrics/src/main/java/org/sonatype/cs/metrics/util/SqlStatements.java
@@ -315,6 +315,11 @@ public class SqlStatements {
                 + " sum(OPEN_COUNT_AT_TIME_PERIOD_END_LICENSE_CRITICAL))/count(time_period_start)"
                 + " as pointA from <?> group by time_period_start order by 1";
 
+    public static final String SCANNINGCOVERAGE =
+            "SELECT TIME_PERIOD_START, SUM(CASE WHEN EVALUATION_COUNT>0 "
+                +"THEN 1 ELSE 0 END) AS pointA, COUNT(*) AS pointB FROM <?> GROUP "
+                +"BY TIME_PERIOD_START";
+
     public static final String RISKRATIOCOMPONENTS =
             "select time_period_start as label,"
                     + " sum(OPEN_COUNT_AT_TIME_PERIOD_END_SECURITY_CRITICAL) as pointA,"

--- a/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.analysis.html.approved.txt
+++ b/view-metrics/src/test/resources/org/sonatype/cs/metrics/SuccessMetricsWebApplicationTest.checkPageContents.analysis.html.approved.txt
@@ -212,10 +212,10 @@
 
             <tr style="font-weight:bold">
                 <td>Scanning Coverage %(apps scanned at least once/period)</td>
-                <td>71.11</td>
-                <td>27.34</td>
-                <td>-43.77</td>
-                <td>-61.55</td>
+                <td>98.28</td>
+                <td>37.06</td>
+                <td>-61.22</td>
+                <td>-62.29</td>
                 <td>0.38</td>
             </tr>
 

--- a/view-metrics/src/test/resources/org/sonatype/cs/metrics/TestSuccessMetricsIsightsApplicationTo202106.checkCSVFileIsGenerated.approved.txt
+++ b/view-metrics/src/test/resources/org/sonatype/cs/metrics/TestSuccessMetricsIsightsApplicationTo202106.checkCSVFileIsGenerated.approved.txt
@@ -2,7 +2,7 @@ Measure,Before (2021-01-01 - 2021-03-01),After (2021-04-01 - 2021-05-01),Delta,C
 Total Onboarded Apps (# of apps),45,107,62.00,137.78,2.38
 Onboarding Rate (apps/period),8.00,31.00,23.00,0.00,3.88
 Total Scans,711.0,298.0,-413.00,-58.09,0.42
-Scanning Coverage %(apps scanned at least once/period),71.11,37.38,-33.73,-47.43,0.53
+Scanning Coverage %(apps scanned at least once/period),98.28,45.44,-52.84,-53.77,0.46
 Scanning Rate (total scans per period),237.00,149.00,-88.00,-37.13,0.63
 Average Scans per App (scanning rate/apps),5.27,1.39,-3.87,-73.56,0.26
 Discovery Rate Criticals (# of discovered Critical violations/period & app),11.52,5.89,-5.63,-48.88,0.51

--- a/view-metrics/src/test/resources/org/sonatype/cs/metrics/TestSuccessMetricsIsightsApplicationTo202107.checkCSVFileIsGenerated.approved.txt
+++ b/view-metrics/src/test/resources/org/sonatype/cs/metrics/TestSuccessMetricsIsightsApplicationTo202107.checkCSVFileIsGenerated.approved.txt
@@ -2,7 +2,7 @@ Measure,Before (2021-01-01 - 2021-03-01),After (2021-04-01 - 2021-06-01),Delta,C
 Total Onboarded Apps (# of apps),45,128,83.00,184.44,2.84
 Onboarding Rate (apps/period),8.00,27.67,19.67,0.00,3.46
 Total Scans,711.0,445.0,-266.00,-37.41,0.63
-Scanning Coverage %(apps scanned at least once/period),71.11,27.34,-43.77,-61.55,0.38
+Scanning Coverage %(apps scanned at least once/period),98.28,37.06,-61.22,-62.29,0.38
 Scanning Rate (total scans per period),237.00,148.33,-88.67,-37.41,0.63
 Average Scans per App (scanning rate/apps),5.27,1.16,-4.11,-78.00,0.22
 Discovery Rate Criticals (# of discovered Critical violations/period & app),11.52,3.93,-7.59,-65.88,0.34


### PR DESCRIPTION
Before this PR the scanning coverage calculation uses the total number of applications at the end of the period
when calculation scanning coverage - this can lead to misleading results if the number of applications is
increasing from period to period (underestimating scanning coverage if the application count is increasing).

After this PR the scanning coverage calculation calculates the ratio of scanned/total applications for each
period and then averages that ratio across the whole period.
