### PR TITLE
Fix StringIndexOutOfBoundsException for license

### DIFF
--- a/get-metrics/src/main/java/org/sonatype/cs/getmetrics/util/ParseReasons.java
+++ b/get-metrics/src/main/java/org/sonatype/cs/getmetrics/util/ParseReasons.java
@@ -2,10 +2,8 @@ package org.sonatype.cs.getmetrics.util;
 
 import org.sonatype.cs.getmetrics.service.PolicyIdsService;
 import org.sonatype.cs.getmetrics.service.UtilService;
-
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 
@@ -52,13 +50,15 @@ public class ParseReasons {
         return cveList;
     }
 
-    private static String getLicense(JsonArray reasons) {
+    public static String getLicense(JsonArray reasons) {
         String licenseList = "";
         List<String> licenses = new ArrayList<>();
 
         for (JsonObject reason : reasons.getValuesAs(JsonObject.class)) {
             String licenseFound = reason.getString("reason");
-
+            if (licenseFound.isEmpty()){
+                continue;
+            }
             String license =
                     licenseFound.substring(
                             licenseFound.indexOf("(") + 1, licenseFound.indexOf(")"));
@@ -69,11 +69,18 @@ public class ParseReasons {
             }
         }
 
-        for (String l : licenses) {
-            licenseList = l + ":" + licenseList;
+        if (licenses.size()==0){
+            return "";
         }
 
-        licenseList = UtilService.removeLastChar(licenseList);
+        for (String l : licenses) {
+            if (licenseList.isEmpty()){
+                licenseList = l;
+            }
+            else{
+                licenseList = licenseList + ":" +l;
+            }
+        }
 
         return licenseList;
     }

--- a/get-metrics/src/test/java/org/sonatype/cs/getmetrics/util/ParseReasonsTest.java
+++ b/get-metrics/src/test/java/org/sonatype/cs/getmetrics/util/ParseReasonsTest.java
@@ -1,0 +1,44 @@
+package org.sonatype.cs.getmetrics.util;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import javax.json.Json;
+import javax.json.JsonArray;
+
+public class ParseReasonsTest {
+    @Test
+    void testEmptyLicenseString() {
+        JsonArray reasons = Json.createArrayBuilder()
+        .add(Json.createObjectBuilder()
+            .add("reason", ""))
+        .build();
+   
+        String actualReason = ParseReasons.getLicense(reasons);
+        Assertions.assertEquals("", actualReason);
+    }
+
+    @Test
+    void testSingleLicenseString() {
+        JsonArray reasons = Json.createArrayBuilder()
+        .add(Json.createObjectBuilder()
+            .add("reason", "(license)"))
+        .build();
+   
+        String actualReason = ParseReasons.getLicense(reasons);
+        Assertions.assertEquals("license", actualReason);
+    }
+
+    @Test
+    void testMultipltLicenseString() {
+        JsonArray reasons = Json.createArrayBuilder()
+        .add(Json.createObjectBuilder()
+            .add("reason", "(license)")
+        )
+        .add(Json.createObjectBuilder()
+            .add("reason", "(license2)")
+        )
+        .build();
+   
+        String actualReason = ParseReasons.getLicense(reasons);
+        Assertions.assertEquals("license:license2", actualReason);
+    }
+}


### PR DESCRIPTION
Before this PR a StringIndexOutOfBoundsException can occur when processing a license which has a missing reason. This
PR fixes that and adds tests for the condition.
